### PR TITLE
Add public origin for Owin middleware

### DIFF
--- a/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
@@ -164,8 +164,8 @@ namespace GSS.Authentication.CAS.Owin
 
         private string BuildReturnTo(string state)
         {
-            return
-                $"{Request.Scheme}://{Request.Host}{RequestPathBase}{Options.CallbackPath}?state={Uri.EscapeDataString(state)}";
+            var publicOrigin = Options.Provider.GetPublicOrigin(Context);
+            return $"{publicOrigin}{Options.CallbackPath}?state={Uri.EscapeDataString(state)}";
         }
     }
 }

--- a/src/GSS.Authentication.CAS.Owin/Provider/CasAuthenticationProvider.cs
+++ b/src/GSS.Authentication.CAS.Owin/Provider/CasAuthenticationProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Microsoft.Owin;
 
 namespace GSS.Authentication.CAS.Owin
 {
@@ -7,13 +8,18 @@ namespace GSS.Authentication.CAS.Owin
     {
         public Func<CasCreatingTicketContext, Task> OnCreatingTicket { get; set; } = context => Task.FromResult(0);
 
+        public Func<IOwinContext, string> OnGetPublicOrigin { get; set; } = context =>
+            $"{context.Request.Scheme}://{context.Request.Host}{context.Request.PathBase}";
+
         public Func<CasRedirectToAuthorizationEndpointContext, Task> OnRedirectToAuthorizationEndpoint { get; set; } = context =>
         {
             context.Response.Redirect(context.RedirectUri);
             return Task.FromResult(0);
         };
-
+        
         public virtual Task CreatingTicket(CasCreatingTicketContext context) => OnCreatingTicket(context);
+
+        public string GetPublicOrigin(IOwinContext context) => OnGetPublicOrigin(context);
 
         public virtual Task RedirectToAuthorizationEndpoint(CasRedirectToAuthorizationEndpointContext context) => OnRedirectToAuthorizationEndpoint(context);
     }

--- a/src/GSS.Authentication.CAS.Owin/Provider/ICasAuthenticationProvider.cs
+++ b/src/GSS.Authentication.CAS.Owin/Provider/ICasAuthenticationProvider.cs
@@ -3,12 +3,16 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Owin;
 
 namespace GSS.Authentication.CAS.Owin
 {
     public interface ICasAuthenticationProvider
     {
         Task CreatingTicket(CasCreatingTicketContext context);
+
+        string GetPublicOrigin(IOwinContext context);
+
         Task RedirectToAuthorizationEndpoint(CasRedirectToAuthorizationEndpointContext context);
     }
 }


### PR DESCRIPTION
Manually setting a public origin allow to use the middleware from a server whose address is not the one called by the browsers.