### PR TITLE
make projects can building on macOS (Rider)

### DIFF
--- a/samples/AspNetMvcSample/AspNetMvcSample.csproj
+++ b/samples/AspNetMvcSample/AspNetMvcSample.csproj
@@ -80,6 +80,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json">
       <Version>2.2.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Condition=" '$(OS)' != 'Windows_NT' ">
+      <Version>1.0.0-*</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Owin.Diagnostics">
       <Version>4.0.1</Version>
     </PackageReference>
@@ -89,12 +92,16 @@
     <PackageReference Include="Microsoft.Owin.Security.Cookies">
       <Version>4.0.1</Version>
     </PackageReference>
+    <PackageReference Include="MSBuild.Microsoft.VisualStudio.Web.targets">
+      <Version>14.0.0.3</Version>
+    </PackageReference>
     <PackageReference Include="Owin.OAuthGeneric">
       <Version>1.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="Exists('$(NuGetPackageRoot)msbuild.microsoft.visualstudio.web.targets\14.0.0.3\tools\vstoospath')">$(NuGetPackageRoot)msbuild.microsoft.visualstudio.web.targets\14.0.0.3\tools\vstoospath</VSToolsPath>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v14.0</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/samples/AspNetMvcSample/Web.config
+++ b/samples/AspNetMvcSample/Web.config
@@ -30,6 +30,10 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
       </dependentAssembly>

--- a/samples/OwinSample/OwinSample.csproj
+++ b/samples/OwinSample/OwinSample.csproj
@@ -68,6 +68,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json">
       <Version>2.2.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Condition=" '$(OS)' != 'Windows_NT' ">
+      <Version>1.0.0-*</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Owin.Diagnostics">
       <Version>4.0.1</Version>
     </PackageReference>
@@ -77,12 +80,16 @@
     <PackageReference Include="Microsoft.Owin.Security.Cookies">
       <Version>4.0.1</Version>
     </PackageReference>
+    <PackageReference Include="MSBuild.Microsoft.VisualStudio.Web.targets">
+      <Version>14.0.0.3</Version>
+    </PackageReference>
     <PackageReference Include="Owin.OAuthGeneric">
       <Version>1.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="Exists('$(NuGetPackageRoot)msbuild.microsoft.visualstudio.web.targets\14.0.0.3\tools\vstoospath')">$(NuGetPackageRoot)msbuild.microsoft.visualstudio.web.targets\14.0.0.3\tools\vstoospath</VSToolsPath>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v14.0</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/samples/OwinSample/Web.config
+++ b/samples/OwinSample/Web.config
@@ -30,6 +30,10 @@
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" culture="neutral" publicKeyToken="31bf3856ad364e35" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
       </dependentAssembly>

--- a/samples/OwinSingleSignOutSample/OwinSingleSignOutSample.csproj
+++ b/samples/OwinSingleSignOutSample/OwinSingleSignOutSample.csproj
@@ -82,6 +82,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>2.2.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Condition=" '$(OS)' != 'Windows_NT' ">
+      <Version>1.0.0-*</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Owin.Diagnostics">
       <Version>4.0.1</Version>
     </PackageReference>
@@ -91,12 +94,16 @@
     <PackageReference Include="Microsoft.Owin.Security.Cookies">
       <Version>4.0.1</Version>
     </PackageReference>
+    <PackageReference Include="MSBuild.Microsoft.VisualStudio.Web.targets">
+      <Version>14.0.0.3</Version>
+    </PackageReference>
     <PackageReference Include="Owin.OAuthGeneric">
       <Version>1.0.3</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="Exists('$(NuGetPackageRoot)msbuild.microsoft.visualstudio.web.targets\14.0.0.3\tools\vstoospath')">$(NuGetPackageRoot)msbuild.microsoft.visualstudio.web.targets\14.0.0.3\tools\vstoospath</VSToolsPath>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v14.0</VSToolsPath>
   </PropertyGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/samples/OwinSingleSignOutSample/Web.config
+++ b/samples/OwinSingleSignOutSample/Web.config
@@ -41,6 +41,10 @@
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-11.0.0.0" newVersion="11.0.0.0"/>
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" culture="neutral" publicKeyToken="b03f5f7f11d50a3a" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.4.1" newVersion="4.0.4.1" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -13,4 +13,8 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(OS)' != 'Windows_NT' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-*" PrivateAssets="All"/>
+  </ItemGroup>
+
 </Project>

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -6,4 +6,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(OS)' != 'Windows_NT' ">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-*" PrivateAssets="All" />
+  </ItemGroup>
+
 </Project>

--- a/test/GSS.Authentication.CAS.Owin.Tests/CasAuthenticationMiddlewareTest.cs
+++ b/test/GSS.Authentication.CAS.Owin.Tests/CasAuthenticationMiddlewareTest.cs
@@ -42,7 +42,7 @@ namespace GSS.Authentication.CAS.Owin.Tests
             var protectionProvider = new FakeDataProtectionProvider(new AesDataProtector("test"));
             _server = TestServer.Create(app =>
             {
-                //app.SetDataProtectionProvider(protectionProvider);
+                app.SetDataProtectionProvider(protectionProvider);
                 app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
                 app.UseCookieAuthentication(new CookieAuthenticationOptions
                 {


### PR DESCRIPTION
- Add MSBuild.Microsoft.VisualStudio.Web.targets for building Web App without Visual Studio
- Add Microsoft.NETFramework.ReferenceAssemblies for cross-platform targeting
- Fix bindingRedirect errors