### PR TITLE
Simplify targeting and dependencies

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -13,8 +13,4 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-*" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-*" PrivateAssets="All"/>
-  </ItemGroup>
-
 </Project>

--- a/src/GSS.Authentication.CAS.AspNetCore/GSS.Authentication.CAS.AspNetCore.csproj
+++ b/src/GSS.Authentication.CAS.AspNetCore/GSS.Authentication.CAS.AspNetCore.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -7,9 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.Abstractions" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GSS.Authentication.CAS.Core/GSS.Authentication.CAS.Core.csproj
+++ b/src/GSS.Authentication.CAS.Core/GSS.Authentication.CAS.Core.csproj
@@ -1,28 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>Core components for CAS Authentication</Description>
     <Version>4.0.0</Version>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <Reference Include="System.Net.Http" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="1.1.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+  <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="3.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.0' ">
     <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/GSS.Authentication.CAS.Owin/GSS.Authentication.CAS.Owin.csproj
+++ b/src/GSS.Authentication.CAS.Owin/GSS.Authentication.CAS.Owin.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Description>OWIN Middlewares for CAS Authentication</Description>
     <Version>4.0.0</Version>
     <NoWarn>$(NoWarn);NU1701</NoWarn>


### PR DESCRIPTION
- Remove unnecessary net461 and netcoreapp3.0 targeting
- Remove unnecessary dependencies
- Update Microsoft.AspNetCore.Authentication.Cookies to 2.1.2