### PR TITLE
HTTPS is required for authentication cookies validation in modern browsers

### DIFF
--- a/samples/OwinSample/Views/Account/Login.cshtml
+++ b/samples/OwinSample/Views/Account/Login.cshtml
@@ -3,6 +3,12 @@
     ViewData["Title"] = "Login";
     var formClass = ViewData["formClass"] ?? "invisible";
 }
+@if (!Request.IsSecureConnection)
+{
+    <div class="alert alert-danger" role="alert">
+        <a href="https://web.dev/samesite-cookies-explained/#samesitenone-must-be-secure">HTTPS</a> is required for authentication cookies validation in modern browsers (<a href="https://www.chromium.org/updates/same-site">since Chrome version 80</a>)
+    </div>
+}
 
 <h1>Choose an authentication scheme</h1>
 

--- a/samples/OwinSingleSignOutSample/Views/Account/Login.cshtml
+++ b/samples/OwinSingleSignOutSample/Views/Account/Login.cshtml
@@ -3,6 +3,12 @@
     ViewData["Title"] = "Login";
     var formClass = ViewData["formClass"] ?? "invisible";
 }
+@if (!Request.IsSecureConnection)
+{
+    <div class="alert alert-danger" role="alert">
+        <a href="https://web.dev/samesite-cookies-explained/#samesitenone-must-be-secure">HTTPS</a> is required for authentication cookies validation in modern browsers (<a href="https://www.chromium.org/updates/same-site">since Chrome version 80</a>)
+    </div>
+}
 
 <h1>Choose an authentication scheme</h1>
 


### PR DESCRIPTION
- https://web.dev/samesite-cookies-explained/#samesitenone-must-be-secure
- https://www.chromium.org/updates/same-site