### PR TITLE
Fixes the service parameter encoding mistake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.1.0 (2022-04-09)
+
+- Fixes the service parameter encoding mistake [#127](https://github.com/akunzai/GSS.Authentication.CAS/pull/127)
+- Default parameter for CancellationToken
+- User attributes may released in CAS v2 protocol with forward-compatible mode [#126](https://github.com/akunzai/GSS.Authentication.CAS/pull/126)
+- Obsolete the ValidateUrlSuffix property
+
 ## 5.0.1 (2021-11-14)
 
 - Fixed System.InvalidOperationException: A suitable constructor for type 'GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware' could not be located

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
-    <Version>5.0.1</Version>
+    <Version>5.1.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release' ">

--- a/src/GSS.Authentication.CAS.Core/Validation/CasServiceTicketValidator.cs
+++ b/src/GSS.Authentication.CAS.Core/Validation/CasServiceTicketValidator.cs
@@ -47,7 +47,7 @@ namespace GSS.Authentication.CAS.Validation
             if (!response.IsSuccessStatusCode)
             {
                 throw new HttpRequestException(
-                    $"Failed to validate ticket [{ticket}] for service [{service}] with error status [{(int)response.StatusCode}], please make sure your CAS server support the validate URI [{validateUri}]");
+                    $"Failed to validate ticket [{ticket}] for service [{service}] with error status [{(int)response.StatusCode}], please make sure your CAS server supports the validation URI [{validateUri}]");
             }
 
             var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/GSS.Authentication.CAS.Core/Validation/CasServiceTicketValidator.cs
+++ b/src/GSS.Authentication.CAS.Core/Validation/CasServiceTicketValidator.cs
@@ -28,7 +28,7 @@ namespace GSS.Authentication.CAS.Validation
         public virtual async Task<ICasPrincipal?> ValidateAsync(
             string ticket,
             string service,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrEmpty(ticket)) throw new ArgumentNullException(nameof(ticket));
             if (string.IsNullOrEmpty(service)) throw new ArgumentNullException(nameof(service));

--- a/src/GSS.Authentication.CAS.Core/Validation/CasServiceTicketValidator.cs
+++ b/src/GSS.Authentication.CAS.Core/Validation/CasServiceTicketValidator.cs
@@ -39,10 +39,9 @@ namespace GSS.Authentication.CAS.Validation
 #pragma warning disable CS0618
             var validateUri = new Uri(baseUri, ValidateUrlSuffix);
 #pragma warning restore CS0618
-            // unescape first to prevent double escape
-            var escapedService = Uri.EscapeDataString(Uri.UnescapeDataString(service));
-            var escapedTicket = Uri.EscapeDataString(ticket);
-            var requestUri = new Uri($"{validateUri.AbsoluteUri}?service={escapedService}&ticket={escapedTicket}");
+            var requestUri =
+                new Uri(
+                    $"{validateUri.AbsoluteUri}?ticket={Uri.EscapeDataString(ticket)}&service={Uri.EscapeDataString(service)}");
             var response = await _httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {

--- a/src/GSS.Authentication.CAS.Core/Validation/IServiceTicketValidator.cs
+++ b/src/GSS.Authentication.CAS.Core/Validation/IServiceTicketValidator.cs
@@ -16,6 +16,8 @@ namespace GSS.Authentication.CAS.Validation
         /// <exception cref="System.Security.Authentication.AuthenticationException"></exception>
         /// <exception cref="System.Net.Http.HttpRequestException"></exception>
         /// <exception cref="System.UriFormatException"></exception>
-        Task<ICasPrincipal?> ValidateAsync(string ticket, string service, CancellationToken cancellationToken);
+        Task<ICasPrincipal?> ValidateAsync(string ticket,
+            string service,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/test/GSS.Authentication.CAS.Core.Tests/Cas10ServiceTicketValidationTests.cs
+++ b/test/GSS.Authentication.CAS.Core.Tests/Cas10ServiceTicketValidationTests.cs
@@ -24,7 +24,7 @@ public class Cas10ServiceTicketValidationTests
         var validator = new Cas10ServiceTicketValidator(_options, new HttpClient(mockHttp));
 
         // Act
-        var principal = await validator.ValidateAsync(ticket, ServiceUrl, CancellationToken.None).ConfigureAwait(false);
+        var principal = await validator.ValidateAsync(ticket, ServiceUrl).ConfigureAwait(false);
 
         //Assert
         Assert.NotNull(principal);
@@ -48,7 +48,9 @@ public class Cas10ServiceTicketValidationTests
         var validator = new Cas10ServiceTicketValidator(_options, new HttpClient(mockHttp));
 
         // Act
-        var principal = await validator.ValidateAsync(ticket, ServiceUrl, CancellationToken.None).ConfigureAwait(false);
+        var principal = await validator.ValidateAsync(ticket, ServiceUrl).ConfigureAwait(false);
+
+        // Assert
         Assert.Null(principal);
         mockHttp.VerifyNoOutstandingRequest();
         mockHttp.VerifyNoOutstandingExpectation();
@@ -69,7 +71,7 @@ public class Cas10ServiceTicketValidationTests
         // Act & Assert
         await Assert
             .ThrowsAsync<HttpRequestException>(
-                () => validator.ValidateAsync(ticket, ServiceUrl, CancellationToken.None)).ConfigureAwait(false);
+                () => validator.ValidateAsync(ticket, ServiceUrl)).ConfigureAwait(false);
         mockHttp.VerifyNoOutstandingRequest();
         mockHttp.VerifyNoOutstandingExpectation();
     }

--- a/test/GSS.Authentication.CAS.Core.Tests/Cas20ServiceTicketValidationTests.cs
+++ b/test/GSS.Authentication.CAS.Core.Tests/Cas20ServiceTicketValidationTests.cs
@@ -62,7 +62,7 @@ public class Cas20ServiceTicketValidationTests
         // Act & Assert
         await Assert
             .ThrowsAsync<AuthenticationException>(() =>
-                validator.ValidateAsync(ticket, ServiceUrl, CancellationToken.None)).ConfigureAwait(false);
+                validator.ValidateAsync(ticket, ServiceUrl)).ConfigureAwait(false);
         mockHttp.VerifyNoOutstandingRequest();
         mockHttp.VerifyNoOutstandingExpectation();
     }
@@ -82,7 +82,7 @@ public class Cas20ServiceTicketValidationTests
         // Act & Assert
         await Assert
             .ThrowsAsync<HttpRequestException>(
-                () => validator.ValidateAsync(ticket, ServiceUrl, CancellationToken.None)).ConfigureAwait(false);
+                () => validator.ValidateAsync(ticket, ServiceUrl)).ConfigureAwait(false);
         mockHttp.VerifyNoOutstandingRequest();
         mockHttp.VerifyNoOutstandingExpectation();
     }

--- a/test/GSS.Authentication.CAS.Core.Tests/Cas30ServiceTicketValidationTests.cs
+++ b/test/GSS.Authentication.CAS.Core.Tests/Cas30ServiceTicketValidationTests.cs
@@ -39,7 +39,7 @@ public class Cas30ServiceTicketValidationTests
         var validator = new Cas30ServiceTicketValidator(_options, new HttpClient(mockHttp));
 
         // Act
-        var principal = await validator.ValidateAsync(ticket, ServiceUrl, CancellationToken.None).ConfigureAwait(false);
+        var principal = await validator.ValidateAsync(ticket, ServiceUrl).ConfigureAwait(false);
 
         //Assert
         Assert.NotNull(principal);
@@ -49,20 +49,22 @@ public class Cas30ServiceTicketValidationTests
         mockHttp.VerifyNoOutstandingRequest();
         mockHttp.VerifyNoOutstandingExpectation();
     }
-    
+
     [Fact]
     public async Task ValidateServiceTicketWithUnsupportedCasServer_ShouldThrowsHttpRequestException()
     {
         // Arrange
         var ticket = Guid.NewGuid().ToString();
-        var requestUrl = $"{_options.CasServerUrlBase}/p3/serviceValidate?ticket={ticket}&service={Uri.EscapeDataString(ServiceUrl)}";
+        var requestUrl =
+            $"{_options.CasServerUrlBase}/p3/serviceValidate?ticket={ticket}&service={Uri.EscapeDataString(ServiceUrl)}";
         var mockHttp = new MockHttpMessageHandler();
         mockHttp.Expect(HttpMethod.Get, requestUrl)
             .Respond(HttpStatusCode.InternalServerError);
         var validator = new Cas30ServiceTicketValidator(_options, new HttpClient(mockHttp));
 
         // Act & Assert
-        await Assert.ThrowsAsync<HttpRequestException>(() => validator.ValidateAsync(ticket, ServiceUrl, CancellationToken.None)).ConfigureAwait(false);
+        await Assert.ThrowsAsync<HttpRequestException>(() => validator.ValidateAsync(ticket, ServiceUrl))
+            .ConfigureAwait(false);
         mockHttp.VerifyNoOutstandingRequest();
         mockHttp.VerifyNoOutstandingExpectation();
     }
@@ -86,7 +88,7 @@ public class Cas30ServiceTicketValidationTests
         // Act & Assert
         await Assert
             .ThrowsAsync<AuthenticationException>(() =>
-                validator.ValidateAsync(ticket, ServiceUrl, CancellationToken.None)).ConfigureAwait(false);
+                validator.ValidateAsync(ticket, ServiceUrl)).ConfigureAwait(false);
         mockHttp.VerifyNoOutstandingRequest();
         mockHttp.VerifyNoOutstandingExpectation();
     }
@@ -106,7 +108,7 @@ public class Cas30ServiceTicketValidationTests
         // Act & Assert
         await Assert
             .ThrowsAsync<HttpRequestException>(
-                () => validator.ValidateAsync(ticket, ServiceUrl, CancellationToken.None)).ConfigureAwait(false);
+                () => validator.ValidateAsync(ticket, ServiceUrl)).ConfigureAwait(false);
         mockHttp.VerifyNoOutstandingRequest();
         mockHttp.VerifyNoOutstandingExpectation();
     }


### PR DESCRIPTION
- [Default parameter for CancellationToken](https://docs.microsoft.com/dotnet/api/system.threading.cancellationtoken.none)
- Fixes typo