### PR TITLE
Improved the IServiceTicketStore implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.2.0 (2022-04-19)
+
+- Bump Microsoft.Owin.Security.Cookies from 4.1.1 to 4.2.0 [#130](https://github.com/akunzai/GSS.Authentication.CAS/pull/130)
+- Improved the IServiceTicketStore implementation [#128](https://github.com/akunzai/GSS.Authentication.CAS/pull/128)
+- Renamed the UseAuthenticationSessionStore to SaveTokens
+
 ## 5.1.0 (2022-04-09)
 
 - Fixes the service parameter encoding mistake [#127](https://github.com/akunzai/GSS.Authentication.CAS/pull/127)

--- a/samples/AspNetCoreIdentitySample/AspNetCoreIdentitySample.csproj
+++ b/samples/AspNetCoreIdentitySample/AspNetCoreIdentitySample.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="6.0.4" />

--- a/samples/AspNetCoreIdentitySample/Program.cs
+++ b/samples/AspNetCoreIdentitySample/Program.cs
@@ -6,9 +6,11 @@ using GSS.Authentication.CAS.AspNetCore;
 using GSS.Authentication.CAS.Validation;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using NLog.Web;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -101,6 +103,34 @@ builder.Services.AddAuthentication()
                 await using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                 using var json = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
                 context.RunClaimActions(json.RootElement);
+            }
+        };
+    })
+    .AddOpenIdConnect(options =>
+    {
+        options.ClientId = builder.Configuration["Authentication:OIDC:ClientId"];
+        options.ClientSecret = builder.Configuration["Authentication:OIDC:ClientSecret"];
+        options.Authority = builder.Configuration["Authentication:OIDC:Authority"];
+        options.MetadataAddress = builder.Configuration["Authentication:OIDC:MetadataAddress"];
+        options.ResponseType = builder.Configuration.GetValue("Authentication:OIDC:ResponseType", OpenIdConnectResponseType.Code);
+        options.ResponseMode = builder.Configuration.GetValue("Authentication:OIDC:ResponseMode", OpenIdConnectResponseMode.Query);
+        options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+        options.Scope.Clear();
+        builder.Configuration.GetValue("Authentication:OIDC:Scope", "openid profile email").Split(" ", StringSplitOptions.RemoveEmptyEntries).ToList().ForEach(s => options.Scope.Add(s));
+        options.Events = new OpenIdConnectEvents
+        {
+            OnRemoteFailure = context =>
+            {
+                var failure = context.Failure;
+                var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<OAuthEvents>>();
+                if (!string.IsNullOrWhiteSpace(failure?.Message))
+                {
+                    logger.LogError(failure, "{Exception}", failure.Message);
+                }
+
+                context.Response.Redirect("/Account/ExternalLoginFailure");
+                context.HandleResponse();
+                return Task.CompletedTask;
             }
         };
     });

--- a/samples/AspNetCoreIdentitySample/appsettings.json
+++ b/samples/AspNetCoreIdentitySample/appsettings.json
@@ -1,15 +1,15 @@
 {
   "Authentication": {
     "CAS": {
-      "ProtocolVersion": 3,
+      "ProtocolVersion": 2,
       "ServerUrlBase": "https://cas.example.org/cas"
     },
     "OAuth": {
       "ClientId": "CHANGE_ME",
       "ClientSecret": "CHANGE_ME",
-      "AuthorizationEndpoint": "https://cas.example.org/oauth2.0/authorize",
-      "TokenEndpoint": "https://cas.example.org/oauth2.0/token",
-      "UserInformationEndpoint": "https://cas.example.org/oauth2.0/profile"
+      "AuthorizationEndpoint": "https://cas.example.org/cas/oauth2.0/authorize",
+      "TokenEndpoint": "https://cas.example.org/cas/oauth2.0/token",
+      "UserInformationEndpoint": "https://cas.example.org/cas/oauth2.0/profile"
     }
   },
   "ConnectionStrings": {

--- a/samples/AspNetCoreIdentitySample/appsettings.json
+++ b/samples/AspNetCoreIdentitySample/appsettings.json
@@ -10,6 +10,11 @@
       "AuthorizationEndpoint": "https://cas.example.org/cas/oauth2.0/authorize",
       "TokenEndpoint": "https://cas.example.org/cas/oauth2.0/token",
       "UserInformationEndpoint": "https://cas.example.org/cas/oauth2.0/profile"
+    },
+    "OIDC": {
+      "Authority": "https://cas.example.org/cas/oidc",
+      "ClientId": "CHANGE_ME",
+      "ClientSecret": "CHANGE_ME"
     }
   },
   "ConnectionStrings": {

--- a/samples/AspNetCoreSample/AspNetCoreSample.csproj
+++ b/samples/AspNetCoreSample/AspNetCoreSample.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.3" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
   </ItemGroup>
 

--- a/samples/AspNetCoreSample/Pages/Index.cshtml
+++ b/samples/AspNetCoreSample/Pages/Index.cshtml
@@ -1,9 +1,9 @@
 @page
 @using Microsoft.AspNetCore.Authentication
+@inject IAuthenticationService _authenticationService
 @model IndexModel
 @{
     ViewData["Title"] = "Home";
-    var accessToken = await HttpContext.GetTokenAsync("access_token");
 }
 <h1>Hello @(User.Identity?.IsAuthenticated == true ? User.Identity.Name : "anonymous")</h1>
 
@@ -17,18 +17,29 @@
             <dd>@claim.Value</dd>
         }
     </dl>
-    @if (!string.IsNullOrWhiteSpace(accessToken))
+    var result = await _authenticationService.AuthenticateAsync(HttpContext, null);
+    var propertiesExcludeToken = result.Properties?.Items.Where(x => !(x.Key.StartsWith(".TokenNames") || x.Key.StartsWith(".Token."))).ToList();
+    if (propertiesExcludeToken?.Any() == true)
+    {
+        <h2>Properties</h2>
+        <dl>
+            @foreach (var (key, value) in propertiesExcludeToken)
+            {
+                <dt>@key</dt>
+                <dd>@value</dd>
+            }
+        </dl>
+    }
+    var tokens = result.Properties?.GetTokens().ToList();
+    @if (tokens?.Any() == true)
     {
         <h2>Tokens</h2>
         <dl>
-            <dt>Access Token</dt>
-            <dd>@accessToken</dd>
-            <dt>Refresh Token</dt>
-            <dd>@await HttpContext.GetTokenAsync("refresh_token")</dd>
-            <dt>Token Type</dt>
-            <dd>@await HttpContext.GetTokenAsync("token_type")</dd>
-            <dt>Expires At</dt>
-            <dd>@await HttpContext.GetTokenAsync("expires_at")</dd>
+            @foreach (var token in tokens)
+            {
+                <dt>@token.Name</dt>
+                <dd>@token.Value</dd>
+            }
         </dl>
     }
     <a class="btn btn-danger" asp-page="/Account/Logout">Logout</a>

--- a/samples/AspNetCoreSample/Program.cs
+++ b/samples/AspNetCoreSample/Program.cs
@@ -55,6 +55,7 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
     .AddCAS(options =>
     {
         options.CasServerUrlBase = builder.Configuration["Authentication:CAS:ServerUrlBase"];
+        options.SaveTokens = builder.Configuration.GetValue("Authentication:CAS:SaveTokens",false);
         var protocolVersion = builder.Configuration.GetValue("Authentication:CAS:ProtocolVersion", 3);
         if (protocolVersion != 3)
         {
@@ -113,6 +114,7 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
         options.ClaimActions.MapJsonKey(ClaimTypes.NameIdentifier, "id");
         options.ClaimActions.MapJsonSubKey(ClaimTypes.Name, "attributes", "display_name");
         options.ClaimActions.MapJsonSubKey(ClaimTypes.Email, "attributes", "email");
+        options.SaveTokens = builder.Configuration.GetValue("Authentication:OAuth:SaveTokens",false);
         options.Events = new OAuthEvents
         {
             OnCreatingTicket = async context =>
@@ -163,6 +165,7 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
         options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
         options.Scope.Clear();
         builder.Configuration.GetValue("Authentication:OIDC:Scope", "openid profile email").Split(" ", StringSplitOptions.RemoveEmptyEntries).ToList().ForEach(s => options.Scope.Add(s));
+        options.SaveTokens = builder.Configuration.GetValue("Authentication:OIDC:SaveTokens",false);
         options.Events = new OpenIdConnectEvents
         {
             OnRemoteFailure = context =>

--- a/samples/AspNetCoreSample/Program.cs
+++ b/samples/AspNetCoreSample/Program.cs
@@ -6,8 +6,10 @@ using GSS.Authentication.CAS.Validation;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using NLog.Web;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -135,6 +137,34 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
                 using var json = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
                 context.RunClaimActions(json.RootElement);
             },
+            OnRemoteFailure = context =>
+            {
+                var failure = context.Failure;
+                var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<OAuthEvents>>();
+                if (!string.IsNullOrWhiteSpace(failure?.Message))
+                {
+                    logger.LogError(failure, "{Exception}", failure.Message);
+                }
+
+                context.Response.Redirect("/Account/ExternalLoginFailure");
+                context.HandleResponse();
+                return Task.CompletedTask;
+            }
+        };
+    })
+    .AddOpenIdConnect(options =>
+    {
+        options.ClientId = builder.Configuration["Authentication:OIDC:ClientId"];
+        options.ClientSecret = builder.Configuration["Authentication:OIDC:ClientSecret"];
+        options.Authority = builder.Configuration["Authentication:OIDC:Authority"];
+        options.MetadataAddress = builder.Configuration["Authentication:OIDC:MetadataAddress"];
+        options.ResponseType = builder.Configuration.GetValue("Authentication:OIDC:ResponseType", OpenIdConnectResponseType.Code);
+        options.ResponseMode = builder.Configuration.GetValue("Authentication:OIDC:ResponseMode", OpenIdConnectResponseMode.Query);
+        options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+        options.Scope.Clear();
+        builder.Configuration.GetValue("Authentication:OIDC:Scope", "openid profile email").Split(" ", StringSplitOptions.RemoveEmptyEntries).ToList().ForEach(s => options.Scope.Add(s));
+        options.Events = new OpenIdConnectEvents
+        {
             OnRemoteFailure = context =>
             {
                 var failure = context.Failure;

--- a/samples/AspNetCoreSample/appsettings.json
+++ b/samples/AspNetCoreSample/appsettings.json
@@ -1,15 +1,15 @@
 {
   "Authentication": {
     "CAS": {
-      "ProtocolVersion": 3,
+      "ProtocolVersion": 2,
       "ServerUrlBase": "https://cas.example.org/cas"
     },
     "OAuth": {
       "ClientId": "CHANGE_ME",
       "ClientSecret": "CHANGE_ME",
-      "AuthorizationEndpoint": "https://cas.example.org/oauth2.0/authorize",
-      "TokenEndpoint": "https://cas.example.org/oauth2.0/token",
-      "UserInformationEndpoint": "https://cas.example.org/oauth2.0/profile"
+      "AuthorizationEndpoint": "https://cas.example.org/cas/oauth2.0/authorize",
+      "TokenEndpoint": "https://cas.example.org/cas/oauth2.0/token",
+      "UserInformationEndpoint": "https://cas.example.org/cas/oauth2.0/profile"
     }
   },
   "Logging": {

--- a/samples/AspNetCoreSample/appsettings.json
+++ b/samples/AspNetCoreSample/appsettings.json
@@ -10,6 +10,11 @@
       "AuthorizationEndpoint": "https://cas.example.org/cas/oauth2.0/authorize",
       "TokenEndpoint": "https://cas.example.org/cas/oauth2.0/token",
       "UserInformationEndpoint": "https://cas.example.org/cas/oauth2.0/profile"
+    },
+    "OIDC": {
+      "Authority": "https://cas.example.org/cas/oidc",
+      "ClientId": "CHANGE_ME",
+      "ClientSecret": "CHANGE_ME"
     }
   },
   "Logging": {

--- a/samples/AspNetCoreSingleLogoutSample/AspNetCoreSingleLogoutSample.csproj
+++ b/samples/AspNetCoreSingleLogoutSample/AspNetCoreSingleLogoutSample.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.4" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.4" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
   </ItemGroup>

--- a/samples/AspNetCoreSingleLogoutSample/Pages/Index.cshtml
+++ b/samples/AspNetCoreSingleLogoutSample/Pages/Index.cshtml
@@ -3,7 +3,6 @@
 @model IndexModel
 @{
     ViewData["Title"] = "Home";
-    var accessToken = await HttpContext.GetTokenAsync("access_token");
 }
 <h1>Hello @(User.Identity?.IsAuthenticated == true ? User.Identity.Name : "anonymous")</h1>
 
@@ -17,20 +16,6 @@
             <dd>@claim.Value</dd>
         }
     </dl>
-    @if (!string.IsNullOrWhiteSpace(accessToken))
-    {
-        <h2>Tokens</h2>
-        <dl>
-            <dt>Access Token</dt>
-            <dd>@accessToken</dd>
-            <dt>Refresh Token</dt>
-            <dd>@await HttpContext.GetTokenAsync("refresh_token")</dd>
-            <dt>Token Type</dt>
-            <dd>@await HttpContext.GetTokenAsync("token_type")</dd>
-            <dt>Expires At</dt>
-            <dd>@await HttpContext.GetTokenAsync("expires_at")</dd>
-        </dl>
-    }
     <a class="btn btn-danger" asp-page="/Account/Logout">Logout</a>
 }
 else

--- a/samples/AspNetCoreSingleLogoutSample/Program.cs
+++ b/samples/AspNetCoreSingleLogoutSample/Program.cs
@@ -10,6 +10,7 @@ using Microsoft.AspNetCore.Authentication.OAuth;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using NLog.Web;
 
@@ -22,7 +23,10 @@ if (!string.IsNullOrWhiteSpace(redisConfiguration))
 {
     builder.Services.AddStackExchangeRedisCache(options => options.Configuration = redisConfiguration);
 }
-
+builder.Services.AddOptions<DistributedCacheServiceTicketStoreOptions>().Configure(options =>
+{
+    options.CacheEntryOptions = new DistributedCacheEntryOptions { SlidingExpiration = TimeSpan.FromHours(8) };
+});
 builder.Services.AddSingleton<IServiceTicketStore, DistributedCacheServiceTicketStore>();
 builder.Services.AddSingleton<ITicketStore, TicketStoreWrapper>();
 

--- a/samples/AspNetCoreSingleLogoutSample/Program.cs
+++ b/samples/AspNetCoreSingleLogoutSample/Program.cs
@@ -7,8 +7,10 @@ using GSS.Authentication.CAS.Validation;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.OAuth;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using NLog.Web;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -150,6 +152,34 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
                 using var json = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
                 context.RunClaimActions(json.RootElement);
             },
+            OnRemoteFailure = context =>
+            {
+                var failure = context.Failure;
+                var logger = context.HttpContext.RequestServices.GetRequiredService<ILogger<OAuthEvents>>();
+                if (!string.IsNullOrWhiteSpace(failure?.Message))
+                {
+                    logger.LogError(failure, "{Exception}", failure.Message);
+                }
+
+                context.Response.Redirect("/Account/ExternalLoginFailure");
+                context.HandleResponse();
+                return Task.CompletedTask;
+            }
+        };
+    })
+    .AddOpenIdConnect(options =>
+    {
+        options.ClientId = builder.Configuration["Authentication:OIDC:ClientId"];
+        options.ClientSecret = builder.Configuration["Authentication:OIDC:ClientSecret"];
+        options.Authority = builder.Configuration["Authentication:OIDC:Authority"];
+        options.MetadataAddress = builder.Configuration["Authentication:OIDC:MetadataAddress"];
+        options.ResponseType = builder.Configuration.GetValue("Authentication:OIDC:ResponseType", OpenIdConnectResponseType.Code);
+        options.ResponseMode = builder.Configuration.GetValue("Authentication:OIDC:ResponseMode", OpenIdConnectResponseMode.Query);
+        options.RequireHttpsMetadata = !builder.Environment.IsDevelopment();
+        options.Scope.Clear();
+        builder.Configuration.GetValue("Authentication:OIDC:Scope", "openid profile email").Split(" ", StringSplitOptions.RemoveEmptyEntries).ToList().ForEach(s => options.Scope.Add(s));
+        options.Events = new OpenIdConnectEvents
+        {
             OnRemoteFailure = context =>
             {
                 var failure = context.Failure;

--- a/samples/AspNetCoreSingleLogoutSample/appsettings.json
+++ b/samples/AspNetCoreSingleLogoutSample/appsettings.json
@@ -1,15 +1,15 @@
 {
   "Authentication": {
     "CAS": {
-      "ProtocolVersion": 3,
+      "ProtocolVersion": 2,
       "ServerUrlBase": "https://cas.example.org/cas"
     },
     "OAuth": {
       "ClientId": "CHANGE_ME",
       "ClientSecret": "CHANGE_ME",
-      "AuthorizationEndpoint": "https://cas.example.org/oauth2.0/authorize",
-      "TokenEndpoint": "https://cas.example.org/oauth2.0/token",
-      "UserInformationEndpoint": "https://cas.example.org/oauth2.0/profile"
+      "AuthorizationEndpoint": "https://cas.example.org/cas/oauth2.0/authorize",
+      "TokenEndpoint": "https://cas.example.org/cas/oauth2.0/token",
+      "UserInformationEndpoint": "https://cas.example.org/cas/oauth2.0/profile"
     }
   },
   "Logging": {

--- a/samples/AspNetCoreSingleLogoutSample/appsettings.json
+++ b/samples/AspNetCoreSingleLogoutSample/appsettings.json
@@ -10,6 +10,11 @@
       "AuthorizationEndpoint": "https://cas.example.org/cas/oauth2.0/authorize",
       "TokenEndpoint": "https://cas.example.org/cas/oauth2.0/token",
       "UserInformationEndpoint": "https://cas.example.org/cas/oauth2.0/profile"
+    },
+    "OIDC": {
+      "Authority": "https://cas.example.org/cas/oidc",
+      "ClientId": "CHANGE_ME",
+      "ClientSecret": "CHANGE_ME"
     }
   },
   "Logging": {

--- a/samples/OwinSample/Controllers/HomeController.cs
+++ b/samples/OwinSample/Controllers/HomeController.cs
@@ -1,4 +1,7 @@
+using System.Threading.Tasks;
+using System.Web;
 using System.Web.Mvc;
+using Microsoft.Owin.Security.Cookies;
 
 namespace OwinSample.Controllers
 {
@@ -6,9 +9,11 @@ namespace OwinSample.Controllers
     public class HomeController : Controller
     {
         [HttpGet]
-        public ActionResult Index()
+        public async Task<ActionResult> Index()
         {
-            return View();
+            if (!User.Identity.IsAuthenticated) return View();
+            var result = await Request.GetOwinContext().Authentication.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationType);
+            return View(result.Properties);
         }
     }
 }

--- a/samples/OwinSample/OwinSample.csproj
+++ b/samples/OwinSample/OwinSample.csproj
@@ -87,6 +87,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json">
       <Version>6.0.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
+      <Version>6.17.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Condition=" '$(OS)' != 'Windows_NT' ">
       <Version>1.0.2</Version>
     </PackageReference>
@@ -94,6 +97,9 @@
       <Version>4.2.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Security.Cookies">
+      <Version>4.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Owin.Security.OpenIdConnect">
       <Version>4.2.1</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.Microsoft.VisualStudio.Web.targets">

--- a/samples/OwinSample/OwinSample.csproj
+++ b/samples/OwinSample/OwinSample.csproj
@@ -78,6 +78,9 @@
     <PackageReference Include="Microsoft.AspNet.Mvc">
       <Version>5.2.8</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
+      <Version>3.6.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder">
       <Version>6.0.0</Version>
     </PackageReference>

--- a/samples/OwinSample/Startup.cs
+++ b/samples/OwinSample/Startup.cs
@@ -92,6 +92,7 @@ namespace OwinSample
             {
                 options.CasServerUrlBase = _configuration["Authentication:CAS:ServerUrlBase"];
                 options.ServiceUrlBase = _configuration.GetValue<Uri>("Authentication:CAS:ServiceUrlBase");
+                options.SaveTokens = _configuration.GetValue("Authentication:CAS:SaveTokens", false);
                 // https://github.com/aspnet/AspNetKatana/wiki/System.Web-response-cookie-integration-issues
                 options.CookieManager = new SystemWebCookieManager();
                 var protocolVersion = _configuration.GetValue("Authentication:CAS:ProtocolVersion", 3);
@@ -104,7 +105,6 @@ namespace OwinSample
                         _ => options.ServiceTicketValidator
                     };
                 }
-
                 options.Provider = new CasAuthenticationProvider
                 {
                     OnCreatingTicket = context =>
@@ -144,6 +144,7 @@ namespace OwinSample
                 options.AuthorizationEndpoint = _configuration["Authentication:OAuth:AuthorizationEndpoint"];
                 options.TokenEndpoint = _configuration["Authentication:OAuth:TokenEndpoint"];
                 options.UserInformationEndpoint = _configuration["Authentication:OAuth:UserInformationEndpoint"];
+                options.SaveTokensAsClaims = _configuration.GetValue("Authentication:OAuth:SaveTokens", false);
                 options.Events = new OAuthEvents
                 {
                     OnCreatingTicket = async context =>
@@ -212,6 +213,7 @@ namespace OwinSample
                 RedeemCode = true,
                 Scope = _configuration.GetValue("Authentication:OIDC:Scope", "openid profile email"),
                 RequireHttpsMetadata = !env.Equals("Development", StringComparison.OrdinalIgnoreCase),
+                SaveTokens = _configuration.GetValue("Authentication:OIDC:SaveTokens", false),
                 Notifications = new OpenIdConnectAuthenticationNotifications
                 {
                     RedirectToIdentityProvider = notification =>

--- a/samples/OwinSample/Views/Home/Index.cshtml
+++ b/samples/OwinSample/Views/Home/Index.cshtml
@@ -1,3 +1,4 @@
+@model Microsoft.Owin.Security.AuthenticationProperties
 @using System.Security.Claims;
 @{
     ViewData["Title"] = "Home";
@@ -15,6 +16,15 @@
             <dd>@claim.Value</dd>
         }
     </dl>
+    if (Model?.Dictionary?.Count > 0)
+    {
+        <h2>Properties</h2>
+        foreach (var prop in Model?.Dictionary)
+        {
+            <dt>@prop.Key</dt>
+            <dd>@prop.Value</dd>
+        }
+    }
     @Html.ActionLink("Logout", "Logout", "Account", null, new { @class = "btn btn-danger" })
 }
 else

--- a/samples/OwinSample/appsettings.json
+++ b/samples/OwinSample/appsettings.json
@@ -10,6 +10,11 @@
       "AuthorizationEndpoint": "https://cas.example.org/cas/oauth2.0/authorize",
       "TokenEndpoint": "https://cas.example.org/cas/oauth2.0/token",
       "UserInformationEndpoint": "https://cas.example.org/cas/oauth2.0/profile"
+    },
+    "OIDC": {
+      "Authority": "https://cas.example.org/cas/oidc",
+      "ClientId": "CHANGE_ME",
+      "ClientSecret": "CHANGE_ME"
     }
   }
 }

--- a/samples/OwinSample/appsettings.json
+++ b/samples/OwinSample/appsettings.json
@@ -1,15 +1,15 @@
 {
   "Authentication": {
     "CAS": {
-      "ProtocolVersion": 3,
+      "ProtocolVersion": 2,
       "ServerUrlBase": "https://example.com/cas"
     },
     "OAuth": {
       "ClientId": "CHANGE_ME",
       "ClientSecret": "CHANGE_ME",
-      "AuthorizationEndpoint": "https://cas.example.org/oauth2.0/authorize",
-      "TokenEndpoint": "https://cas.example.org/oauth2.0/token",
-      "UserInformationEndpoint": "https://cas.example.org/oauth2.0/profile"
+      "AuthorizationEndpoint": "https://cas.example.org/cas/oauth2.0/authorize",
+      "TokenEndpoint": "https://cas.example.org/cas/oauth2.0/token",
+      "UserInformationEndpoint": "https://cas.example.org/cas/oauth2.0/profile"
     }
   }
 }

--- a/samples/OwinSample/web.config
+++ b/samples/OwinSample/web.config
@@ -1,88 +1,104 @@
 <?xml version="1.0"?>
 <configuration>
   <system.web>
-    <authentication mode="None" />
-    <compilation debug="true" targetFramework="4.8" />
-    <httpRuntime targetFramework="4.8" />
+    <authentication mode="None"/>
+    <compilation debug="true" targetFramework="4.8"/>
+    <httpRuntime targetFramework="4.8"/>
     <!-- https://github.com/aspnet/AspNetKatana/wiki/System.Web-response-cookie-integration-issues -->
-    <sessionState mode="Off" />
+    <sessionState mode="Off"/>
   </system.web>
   <system.webServer>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <remove name="OPTIONSVerbHandler" />
-      <remove name="TRACEVerbHandler" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <remove name="OPTIONSVerbHandler"/>
+      <remove name="TRACEVerbHandler"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
     </handlers>
     <modules>
-      <remove name="FormsAuthentication" />
+      <remove name="FormsAuthentication"/>
     </modules>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.17.0.0" newVersion="6.17.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.17.0.0" newVersion="6.17.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.FileExtensions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.17.0.0" newVersion="6.17.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.17.0.0" newVersion="6.17.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Physical" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileSystemGlobbing" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.FileExtensions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Physical" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+        <assemblyIdentity name="Microsoft.Extensions.FileSystemGlobbing" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1" />
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/samples/OwinSample/web.config
+++ b/samples/OwinSample/web.config
@@ -18,6 +18,16 @@
       <remove name="FormsAuthentication"/>
     </modules>
   </system.webServer>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs"
+                type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+                warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb"
+                type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+                warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+    </compilers>
+  </system.codedom>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/samples/OwinSingleLogoutSample/OwinSingleLogoutSample.csproj
+++ b/samples/OwinSingleLogoutSample/OwinSingleLogoutSample.csproj
@@ -96,6 +96,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection">
       <Version>6.0.0</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect">
+      <Version>6.17.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Condition=" '$(OS)' != 'Windows_NT' ">
       <Version>1.0.2</Version>
     </PackageReference>
@@ -103,6 +106,9 @@
       <Version>4.2.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Owin.Security.Cookies">
+      <Version>4.2.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Owin.Security.OpenIdConnect">
       <Version>4.2.1</Version>
     </PackageReference>
     <PackageReference Include="MSBuild.Microsoft.VisualStudio.Web.targets">

--- a/samples/OwinSingleLogoutSample/OwinSingleLogoutSample.csproj
+++ b/samples/OwinSingleLogoutSample/OwinSingleLogoutSample.csproj
@@ -78,6 +78,9 @@
     <PackageReference Include="Microsoft.AspNet.Mvc">
       <Version>5.2.8</Version>
     </PackageReference>
+    <PackageReference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform">
+      <Version>3.6.0</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory">
       <Version>6.0.1</Version>
     </PackageReference>

--- a/samples/OwinSingleLogoutSample/Startup.cs
+++ b/samples/OwinSingleLogoutSample/Startup.cs
@@ -13,6 +13,7 @@ using GSS.Authentication.CAS;
 using GSS.Authentication.CAS.Owin;
 using GSS.Authentication.CAS.Security;
 using GSS.Authentication.CAS.Validation;
+using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
@@ -105,7 +106,7 @@ namespace OwinSingleLogoutSample
                 // https://github.com/aspnet/AspNetKatana/wiki/System.Web-response-cookie-integration-issues
                 options.CookieManager = new SystemWebCookieManager();
                 // required for CasSingleLogoutMiddleware
-                options.UseAuthenticationSessionStore = true;
+                options.SaveTokens = true;
                 var protocolVersion = _configuration.GetValue("Authentication:CAS:ProtocolVersion", 3);
                 if (protocolVersion != 3)
                 {
@@ -266,6 +267,10 @@ namespace OwinSingleLogoutSample
             {
                 services.AddStackExchangeRedisCache(options => options.Configuration = redisConfiguration);
             }
+
+            services.AddOptions<DistributedCacheServiceTicketStoreOptions>().Configure(options =>
+                options.CacheEntryOptions =
+                    new DistributedCacheEntryOptions { SlidingExpiration = TimeSpan.FromHours(8) });
 
             services
                 .AddSingleton(_configuration)

--- a/samples/OwinSingleLogoutSample/Startup.cs
+++ b/samples/OwinSingleLogoutSample/Startup.cs
@@ -15,10 +15,12 @@ using GSS.Authentication.CAS.Security;
 using GSS.Authentication.CAS.Validation;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.Owin;
 using Microsoft.Owin.Host.SystemWeb;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
+using Microsoft.Owin.Security.OpenIdConnect;
 using NLog;
 using NLog.Owin.Logging;
 using Owin;
@@ -206,6 +208,53 @@ namespace OwinSingleLogoutSample
                         return Task.CompletedTask;
                     }
                 };
+            });
+
+            app.UseOpenIdConnectAuthentication(new OpenIdConnectAuthenticationOptions
+            {
+                AuthenticationMode = AuthenticationMode.Passive,
+                CallbackPath = new PathString("/signin-oidc"),
+                ClientId = _configuration["Authentication:OIDC:ClientId"],
+                ClientSecret = _configuration["Authentication:OIDC:ClientSecret"],
+                Authority = _configuration["Authentication:OIDC:Authority"],
+                MetadataAddress = _configuration["Authentication:OIDC:MetadataAddress"],
+                ResponseType = _configuration.GetValue("Authentication:OIDC:ResponseType", OpenIdConnectResponseType.Code),
+                ResponseMode = _configuration.GetValue("Authentication:OIDC:ResponseMode", OpenIdConnectResponseMode.Query),
+                // Avoid 404 error when redirecting to the callback path. see https://github.com/aspnet/AspNetKatana/issues/348
+                RedeemCode = true,
+                Scope = _configuration.GetValue("Authentication:OIDC:Scope", "openid profile email"),
+                RequireHttpsMetadata = !env.Equals("Development", StringComparison.OrdinalIgnoreCase),
+                Notifications = new OpenIdConnectAuthenticationNotifications
+                {
+                    RedirectToIdentityProvider = notification =>
+                    {
+                        // generate the redirect_uri parameter automatically
+                        if (string.IsNullOrWhiteSpace(notification.Options.RedirectUri))
+                        {
+                            var redirectUri = notification.Request.Scheme + Uri.SchemeDelimiter + notification.Request.Host + notification.Request.PathBase + notification.Options.CallbackPath;
+                            notification.ProtocolMessage.RedirectUri = redirectUri;
+                        }
+                        return Task.CompletedTask;
+                    },
+                    AuthorizationCodeReceived = notification =>
+                    {
+                        // generate the redirect_uri parameter automatically
+                        if (string.IsNullOrWhiteSpace(notification.Options.RedirectUri))
+                        {
+                            var redirectUri = notification.Request.Scheme + Uri.SchemeDelimiter + notification.Request.Host + notification.Request.PathBase + notification.Options.CallbackPath;
+                            notification.TokenEndpointRequest.RedirectUri = redirectUri;
+                        }
+                        return Task.CompletedTask;
+                    },
+                    AuthenticationFailed = notification =>
+                    {
+                        var exception = notification.Exception;
+                        _logger.Error(exception, exception.Message);
+                        notification.Response.Redirect("/Account/ExternalLoginFailure");
+                        notification.HandleResponse();
+                        return Task.CompletedTask;
+                    }
+                }
             });
         }
 

--- a/samples/OwinSingleLogoutSample/appsettings.json
+++ b/samples/OwinSingleLogoutSample/appsettings.json
@@ -10,6 +10,11 @@
       "AuthorizationEndpoint": "https://cas.example.org/cas/oauth2.0/authorize",
       "TokenEndpoint": "https://cas.example.org/cas/oauth2.0/token",
       "UserInformationEndpoint": "https://cas.example.org/cas/oauth2.0/profile"
+    },
+    "OIDC": {
+      "Authority": "https://cas.example.org/cas/oidc",
+      "ClientId": "CHANGE_ME",
+      "ClientSecret": "CHANGE_ME"
     }
   }
 }

--- a/samples/OwinSingleLogoutSample/appsettings.json
+++ b/samples/OwinSingleLogoutSample/appsettings.json
@@ -1,15 +1,15 @@
 {
   "Authentication": {
     "CAS": {
-      "ProtocolVersion": 3,
+      "ProtocolVersion": 2,
       "ServerUrlBase": "https://cas.example.org/cas"
     },
     "OAuth": {
       "ClientId": "CHANGE_ME",
       "ClientSecret": "CHANGE_ME",
-      "AuthorizationEndpoint": "https://cas.example.org/oauth2.0/authorize",
-      "TokenEndpoint": "https://cas.example.org/oauth2.0/token",
-      "UserInformationEndpoint": "https://cas.example.org/oauth2.0/profile"
+      "AuthorizationEndpoint": "https://cas.example.org/cas/oauth2.0/authorize",
+      "TokenEndpoint": "https://cas.example.org/cas/oauth2.0/token",
+      "UserInformationEndpoint": "https://cas.example.org/cas/oauth2.0/profile"
     }
   }
 }

--- a/samples/OwinSingleLogoutSample/web.config
+++ b/samples/OwinSingleLogoutSample/web.config
@@ -18,6 +18,16 @@
       <remove name="FormsAuthentication"/>
     </modules>
   </system.webServer>
+  <system.codedom>
+    <compilers>
+      <compiler language="c#;cs;csharp" extension=".cs"
+                type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.CSharpCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+                warningLevel="4" compilerOptions="/langversion:default /nowarn:1659;1699;1701" />
+      <compiler language="vb;vbs;visualbasic;vbscript" extension=".vb"
+                type="Microsoft.CodeDom.Providers.DotNetCompilerPlatform.VBCodeProvider, Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=3.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35"
+                warningLevel="4" compilerOptions="/langversion:default /nowarn:41008 /define:_MYTYPE=\&quot;Web\&quot; /optionInfer+" />
+    </compilers>
+  </system.codedom>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>

--- a/samples/OwinSingleLogoutSample/web.config
+++ b/samples/OwinSingleLogoutSample/web.config
@@ -1,112 +1,128 @@
 <?xml version="1.0"?>
 <configuration>
   <system.web>
-    <authentication mode="None" />
-    <compilation debug="true" targetFramework="4.8" />
-    <httpRuntime targetFramework="4.8" />
+    <authentication mode="None"/>
+    <compilation debug="true" targetFramework="4.8"/>
+    <httpRuntime targetFramework="4.8"/>
     <!-- https://github.com/aspnet/AspNetKatana/wiki/System.Web-response-cookie-integration-issues -->
-    <sessionState mode="Off" />
+    <sessionState mode="Off"/>
   </system.web>
   <system.webServer>
     <handlers>
-      <remove name="ExtensionlessUrlHandler-Integrated-4.0" />
-      <remove name="OPTIONSVerbHandler" />
-      <remove name="TRACEVerbHandler" />
-      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0" />
+      <remove name="ExtensionlessUrlHandler-Integrated-4.0"/>
+      <remove name="OPTIONSVerbHandler"/>
+      <remove name="TRACEVerbHandler"/>
+      <add name="ExtensionlessUrlHandler-Integrated-4.0" path="*." verb="*" type="System.Web.Handlers.TransferRequestHandler" preCondition="integratedMode,runtimeVersionv4.0"/>
     </handlers>
     <modules>
-      <remove name="FormsAuthentication" />
+      <remove name="FormsAuthentication"/>
     </modules>
   </system.webServer>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.17.0.0" newVersion="6.17.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Tokens" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.17.0.0" newVersion="6.17.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols.OpenIdConnect" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.17.0.0" newVersion="6.17.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.IdentityModel.Protocols" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.17.0.0" newVersion="6.17.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.FileExtensions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Caching.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Physical" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.FileSystemGlobbing" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Configuration.FileExtensions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0" />
+        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Microsoft.Extensions.FileProviders.Physical" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+        <assemblyIdentity name="Microsoft.Extensions.FileSystemGlobbing" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-3.1.9.0" newVersion="3.1.9.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31BF3856AD364E35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="ADB9793829DDAE60" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+        <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="Microsoft.Owin.Security" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1" />
+        <assemblyIdentity name="Microsoft.Owin.Security.Cookies" publicKeyToken="31BF3856AD364E35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1" />
+        <assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.1" newVersion="5.0.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.1" newVersion="4.2.0.1"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.3.0" newVersion="4.0.3.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
-    <Version>5.1.0</Version>
+    <Version>5.2.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release' ">

--- a/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using System.Threading.Tasks;
@@ -96,10 +95,7 @@ namespace GSS.Authentication.CAS.AspNetCore
 
             if (Options.SaveTokens)
             {
-                properties.StoreTokens(new List<AuthenticationToken>
-                {
-                    new AuthenticationToken {Name = "access_token", Value = serviceTicket}
-                });
+                properties.SetServiceTicket(serviceTicket);
             }
 
             var ticket = await CreateTicketAsync(principal as ClaimsPrincipal ?? new ClaimsPrincipal(principal),

--- a/src/GSS.Authentication.CAS.AspNetCore/TicketStoreWrapper.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/TicketStoreWrapper.cs
@@ -42,7 +42,7 @@ namespace GSS.Authentication.CAS.AspNetCore
 
         private static ServiceTicket BuildServiceTicket(AuthenticationTicket ticket)
         {
-            var ticketId = ticket.Properties.GetTokenValue("access_token") ?? Guid.NewGuid().ToString();
+            var ticketId = ticket.Properties.GetServiceTicket() ?? Guid.NewGuid().ToString();
             var principal = ticket.Principal;
             var properties = ticket.Properties;
             var assertion = (principal as CasPrincipal)?.Assertion

--- a/src/GSS.Authentication.CAS.AspNetCore/TicketStoreWrapper.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/TicketStoreWrapper.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using GSS.Authentication.CAS.Security;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 
@@ -17,10 +16,10 @@ namespace GSS.Authentication.CAS.AspNetCore
             _store = store;
         }
 
-        public Task<string> StoreAsync(AuthenticationTicket ticket)
+        public async Task<string> StoreAsync(AuthenticationTicket ticket)
         {
             var serviceTicket = BuildServiceTicket(ticket);
-            return _store.StoreAsync(serviceTicket);
+            return await _store.StoreAsync(serviceTicket).ConfigureAwait(false);
         }
 
         public async Task<AuthenticationTicket?> RetrieveAsync(string key)
@@ -29,56 +28,34 @@ namespace GSS.Authentication.CAS.AspNetCore
             return ticket == null ? null : BuildAuthenticationTicket(ticket);
         }
 
-        public Task RenewAsync(string key, AuthenticationTicket ticket)
+        public async Task RenewAsync(string key, AuthenticationTicket ticket)
         {
             var serviceTicket = BuildServiceTicket(ticket);
-            return _store.RenewAsync(key, serviceTicket);
+            await _store.RenewAsync(key, serviceTicket).ConfigureAwait(false);
         }
 
-        public Task RemoveAsync(string key)
+        public async Task RemoveAsync(string key)
         {
-            return _store.RemoveAsync(key);
+            await _store.RemoveAsync(key).ConfigureAwait(false);
         }
 
         private static ServiceTicket BuildServiceTicket(AuthenticationTicket ticket)
         {
-            var ticketId = ticket.Properties.GetServiceTicket() ?? Guid.NewGuid().ToString();
-            var principal = ticket.Principal;
-            var properties = ticket.Properties;
-            var assertion = (principal as CasPrincipal)?.Assertion
-                ?? (principal.Identity as CasIdentity)?.Assertion
-                ?? new Assertion(
-                    principal.GetPrincipalName(),
-                    null, properties.IssuedUtc,
-                    properties.ExpiresUtc);
-            return new ServiceTicket(ticketId, assertion, principal.Claims, principal.Identity.AuthenticationType);
+            return new ServiceTicket(
+                ticket.Properties.GetServiceTicket() ?? Guid.NewGuid().ToString(),
+                ticket.Principal.Claims,
+                string.IsNullOrWhiteSpace(ticket.Principal.Identity.AuthenticationType)
+                    ? ticket.AuthenticationScheme
+                    : ticket.Principal.Identity.AuthenticationType,
+                ticket.Properties.IssuedUtc,
+                ticket.Properties.ExpiresUtc);
         }
 
         private static AuthenticationTicket BuildAuthenticationTicket(ServiceTicket ticket)
         {
-            var assertion = ticket.Assertion;
-            var principal = new CasPrincipal(assertion, ticket.AuthenticationType);
-            if (principal.Identity is not ClaimsIdentity identity)
-            {
-                return new AuthenticationTicket(
-                   principal,
-                   new AuthenticationProperties
-                   {
-                       IssuedUtc = assertion.ValidFrom,
-                       ExpiresUtc = assertion.ValidUntil
-                   },
-                   ticket.AuthenticationType);
-            }
-
-            identity.AddClaims(ticket.Claims);
-
             return new AuthenticationTicket(
-                principal,
-                new AuthenticationProperties
-                {
-                    IssuedUtc = assertion.ValidFrom,
-                    ExpiresUtc = assertion.ValidUntil
-                },
+                new ClaimsPrincipal(new ClaimsIdentity(ticket.Claims, ticket.AuthenticationType)),
+                new AuthenticationProperties { IssuedUtc = ticket.ValidFrom, ExpiresUtc = ticket.ValidUntil },
                 ticket.AuthenticationType);
         }
     }

--- a/src/GSS.Authentication.CAS.AspNetCore/TicketStoreWrapperExtensions.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/TicketStoreWrapperExtensions.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Authentication;
+
+namespace GSS.Authentication.CAS.AspNetCore
+{
+    public static class TicketStoreWrapperExtensions
+    {
+        private const string ServiceTicketKey = "access_token";
+
+        public static void SetServiceTicket(this AuthenticationProperties properties, string ticket)
+        {
+            properties.StoreTokens(new List<AuthenticationToken> { new() { Name = ServiceTicketKey, Value = ticket } });
+        }
+
+        public static string? GetServiceTicket(this AuthenticationProperties properties)
+        {
+            var ticket = properties.GetTokenValue(ServiceTicketKey);
+            return string.IsNullOrWhiteSpace(ticket) ? null : ticket;
+        }
+    }
+}

--- a/src/GSS.Authentication.CAS.AspNetCore/TicketStoreWrapperExtensions.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/TicketStoreWrapperExtensions.cs
@@ -5,7 +5,7 @@ namespace GSS.Authentication.CAS.AspNetCore
 {
     public static class TicketStoreWrapperExtensions
     {
-        private const string ServiceTicketKey = "access_token";
+        private const string ServiceTicketKey = "service_ticket";
 
         public static void SetServiceTicket(this AuthenticationProperties properties, string ticket)
         {

--- a/src/GSS.Authentication.CAS.Core/Security/Assertion.cs
+++ b/src/GSS.Authentication.CAS.Core/Security/Assertion.cs
@@ -15,16 +15,20 @@ namespace GSS.Authentication.CAS.Security
             if (string.IsNullOrWhiteSpace(principalName)) throw new ArgumentNullException(nameof(principalName));
             PrincipalName = principalName;
             Attributes = attributes ?? new Dictionary<string, StringValues>();
+#pragma warning disable CS0618
             ValidFrom = validFrom;
             ValidUntil = validUntil;
+#pragma warning restore CS0618
         }
 
         public string PrincipalName { get; }
 
         public IDictionary<string, StringValues> Attributes { get; }
 
+        [Obsolete("Will be removed in future release.")]
         public DateTimeOffset? ValidFrom { get; }
 
+        [Obsolete("Will be removed in future release.")]
         public DateTimeOffset? ValidUntil { get; }
     }
 }

--- a/src/GSS.Authentication.CAS.Core/ServiceTicket.cs
+++ b/src/GSS.Authentication.CAS.Core/ServiceTicket.cs
@@ -7,22 +7,54 @@ namespace GSS.Authentication.CAS
 {
     public class ServiceTicket
     {
-        public ServiceTicket(string ticketId, Assertion assertion, IEnumerable<Claim> claims, string authenticationType)
+        [Obsolete("Use another constructor instead.")]
+        public ServiceTicket(string ticketId,
+            Assertion? assertion,
+            IEnumerable<Claim> claims,
+            string authenticationType,
+            DateTimeOffset? validFrom = null,
+            DateTimeOffset? validUntil = null)
         {
             if (string.IsNullOrWhiteSpace(ticketId)) throw new ArgumentNullException(nameof(ticketId));
-            if (string.IsNullOrWhiteSpace(authenticationType)) throw new ArgumentNullException(nameof(authenticationType));
+            if (string.IsNullOrWhiteSpace(authenticationType))
+                throw new ArgumentNullException(nameof(authenticationType));
             TicketId = ticketId;
-            Assertion = assertion ?? throw new ArgumentNullException(nameof(assertion));
+#pragma warning disable CS0618
+            Assertion = assertion;
+#pragma warning restore CS0618
             Claims = claims;
             AuthenticationType = authenticationType;
+            ValidFrom = validFrom;
+            ValidUntil = validUntil;
+        }
+        
+        public ServiceTicket(string ticketId,
+            IEnumerable<Claim> claims,
+            string authenticationType,
+            DateTimeOffset? validFrom = null,
+            DateTimeOffset? validUntil = null)
+        {
+            if (string.IsNullOrWhiteSpace(ticketId)) throw new ArgumentNullException(nameof(ticketId));
+            if (string.IsNullOrWhiteSpace(authenticationType))
+                throw new ArgumentNullException(nameof(authenticationType));
+            TicketId = ticketId;
+            Claims = claims;
+            AuthenticationType = authenticationType;
+            ValidFrom = validFrom;
+            ValidUntil = validUntil;
         }
 
         public string TicketId { get; }
 
         public string AuthenticationType { get; }
 
-        public Assertion Assertion { get; }
+        [Obsolete("Use Claims instead. Will be removed in future release.")]
+        public Assertion? Assertion { get; }
 
         public IEnumerable<Claim> Claims { get; }
+
+        public DateTimeOffset? ValidFrom { get; }
+
+        public DateTimeOffset? ValidUntil { get; }  
     }
 }

--- a/src/GSS.Authentication.CAS.DistributedCache/DistributedCacheServiceTicketStoreOptions.cs
+++ b/src/GSS.Authentication.CAS.DistributedCache/DistributedCacheServiceTicketStoreOptions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Text.Json;
+using Microsoft.Extensions.Caching.Distributed;
+
+namespace GSS.Authentication.CAS
+{
+    public class DistributedCacheServiceTicketStoreOptions
+    {
+        public static readonly DistributedCacheServiceTicketStoreOptions Default =
+            new DistributedCacheServiceTicketStoreOptions();
+        
+        internal const string Prefix = "CAS-ST";
+        
+        public Func<string, string> CacheKeyFactory { get; set; } = key => $"{Prefix}:{key}";
+
+        public JsonSerializerOptions? SerializerOptions { get; set; }
+        
+        public DistributedCacheEntryOptions CacheEntryOptions { get; set; } = new DistributedCacheEntryOptions();
+    }
+}

--- a/src/GSS.Authentication.CAS.DistributedCache/GSS.Authentication.CAS.DistributedCache.csproj
+++ b/src/GSS.Authentication.CAS.DistributedCache/GSS.Authentication.CAS.DistributedCache.csproj
@@ -7,11 +7,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0"/>
+    <PackageReference Include="Microsoft.Extensions.Options" Version="2.2.0"/>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\GSS.Authentication.CAS.Core\GSS.Authentication.CAS.Core.csproj" />
+    <ProjectReference Include="..\GSS.Authentication.CAS.Core\GSS.Authentication.CAS.Core.csproj"/>
   </ItemGroup>
-  
+
 </Project>

--- a/src/GSS.Authentication.CAS.DistributedCache/Internal/AssertionHolder.cs
+++ b/src/GSS.Authentication.CAS.DistributedCache/Internal/AssertionHolder.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Primitives;
@@ -15,23 +14,13 @@ namespace GSS.Authentication.CAS.Internal
         {
             PrincipalName = assertion.PrincipalName;
             Attributes = assertion.Attributes.ToDictionary(x => x.Key, x => x.Value.ToArray());
-            ValidFrom = assertion.ValidFrom;
-            ValidUntil = assertion.ValidUntil;
         }
 
         public string PrincipalName { get; set; }
 
         public IDictionary<string, string[]> Attributes { get; set; }
 
-        public DateTimeOffset? ValidFrom { get; set; }
-
-        public DateTimeOffset? ValidUntil { get; set; }
-
         public static explicit operator Assertion(AssertionHolder h) =>
-            new Assertion(
-                h.PrincipalName,
-                h.Attributes.ToDictionary(x => x.Key, x => new StringValues(x.Value)),
-                h.ValidFrom,
-                h.ValidUntil);
+            new Assertion(h.PrincipalName, h.Attributes.ToDictionary(x => x.Key, x => new StringValues(x.Value)));
     }
 }

--- a/src/GSS.Authentication.CAS.DistributedCache/Internal/ClaimHolder.cs
+++ b/src/GSS.Authentication.CAS.DistributedCache/Internal/ClaimHolder.cs
@@ -22,6 +22,7 @@ namespace GSS.Authentication.CAS.Internal
         public string Issuer { get; set; }
         public string OriginalIssuer { get; set; }
 
-        public static explicit operator Claim(ClaimHolder w) => new Claim(w.Type, w.Value, w.ValueType, w.Issuer, w.OriginalIssuer);
+        public static explicit operator Claim(ClaimHolder w) =>
+            new Claim(w.Type, w.Value, w.ValueType, w.Issuer, w.OriginalIssuer);
     }
 }

--- a/src/GSS.Authentication.CAS.DistributedCache/Internal/ServiceTicketHolder.cs
+++ b/src/GSS.Authentication.CAS.DistributedCache/Internal/ServiceTicketHolder.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
-using GSS.Authentication.CAS.Security;
 
 namespace GSS.Authentication.CAS.Internal
 {
@@ -14,7 +13,6 @@ namespace GSS.Authentication.CAS.Internal
         {
             TicketId = ticket.TicketId;
             AuthenticationType = ticket.AuthenticationType;
-            Assertion = new AssertionHolder(ticket.Assertion);
             Claims = ticket.Claims.Select(x=> new ClaimHolder(x));
         }
 
@@ -22,10 +20,9 @@ namespace GSS.Authentication.CAS.Internal
 
         public string AuthenticationType { get; set; }
 
-        public AssertionHolder Assertion { get; set; }
-
         public IEnumerable<ClaimHolder> Claims { get; set; }
 
-        public static explicit operator ServiceTicket(ServiceTicketHolder h) => new ServiceTicket(h.TicketId, (Assertion)h.Assertion, h.Claims.Select(x => (Claim)x), h.AuthenticationType);
+        public static explicit operator ServiceTicket(ServiceTicketHolder h) =>
+            new ServiceTicket(h.TicketId, h.Claims.Select(x => (Claim)x), h.AuthenticationType);
     }
 }

--- a/src/GSS.Authentication.CAS.Owin/AuthenticationSessionStoreExtensions.cs
+++ b/src/GSS.Authentication.CAS.Owin/AuthenticationSessionStoreExtensions.cs
@@ -4,7 +4,7 @@ namespace GSS.Authentication.CAS.Owin
 {
     public static class AuthenticationSessionStoreExtensions
     {
-        private const string ServiceTicketKey = "ServiceTicket";
+        private const string ServiceTicketKey = "service_ticket";
 
         public static void SetServiceTicket(this AuthenticationProperties properties, string ticket)
         {

--- a/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
@@ -163,9 +163,9 @@ namespace GSS.Authentication.CAS.Owin
                 return new AuthenticationTicket(null, properties);
             }
 
-            if (Options.UseAuthenticationSessionStore)
+            if (Options.SaveTokens)
             {
-                // store serviceTicket for single sign out
+                // store the service_ticket for single logout
                 properties.SetServiceTicket(ticket);
             }
 

--- a/src/GSS.Authentication.CAS.Owin/CasAuthenticationOptions.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasAuthenticationOptions.cs
@@ -56,10 +56,25 @@ namespace GSS.Authentication.CAS.Owin
         /// </summary>
         public string? SignInAsAuthenticationType { get; set; }
 
+        [Obsolete("Use SaveTokens instead.")]
+        public bool UseAuthenticationSessionStore
+        {
+            get
+            {
+                return SaveTokens;
+            }
+            set
+            {
+                SaveTokens = value;
+            }
+        }
+
         /// <summary>
-        /// store serviceTicket in AuthenticationProperties for single sign out ?
+        /// Defines whether <c>service_ticket</c> tokens should be stored in the
+        /// <see cref="AuthenticationProperties"/> after a successful authorization.
+        /// This property needs set to <c>true</c> for single-logout to work.
         /// </summary>
-        public bool UseAuthenticationSessionStore { get; set; }
+        public bool SaveTokens { get; set; }
 
         /// <summary>
         /// Gets or sets the type used to secure data handled by the middleware.

--- a/test/GSS.Authentication.CAS.AspNetCore.Tests/TicketStoreWrapperTests.cs
+++ b/test/GSS.Authentication.CAS.AspNetCore.Tests/TicketStoreWrapperTests.cs
@@ -1,0 +1,198 @@
+using System.Security.Claims;
+using System.Security.Principal;
+using Microsoft.AspNetCore.Authentication;
+using Moq;
+using Xunit;
+
+namespace GSS.Authentication.CAS.AspNetCore.Tests
+{
+    public class TicketStoreWrapperTests
+    {
+        [Fact]
+        public async Task StoreGenericPrincipal_ShouldNotThrows()
+        {
+            // Arrange
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            serviceTickets.Setup(x => x.StoreAsync(It.IsAny<ServiceTicket>()))
+                .Returns<ServiceTicket>(ticket => Task.FromResult(ticket.TicketId)).Verifiable();
+            var tickets = new TicketStoreWrapper(serviceTickets.Object);
+            var authenticationTicket =
+                new AuthenticationTicket(new GenericPrincipal(new GenericIdentity("TEST"), new[] { "TEST" }), "TEST");
+
+            // Act
+            var actual = await tickets.StoreAsync(authenticationTicket);
+
+            // Assert
+            Assert.NotNull(actual);
+            serviceTickets.Verify();
+        }
+
+        [Fact]
+        public async Task StoreClaimsIdentity_ShouldNotThrows()
+        {
+            // Arrange
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            serviceTickets.Setup(x => x.StoreAsync(It.IsAny<ServiceTicket>()))
+                .Returns<ServiceTicket>(ticket => Task.FromResult(ticket.TicketId)).Verifiable();
+            var tickets = new TicketStoreWrapper(serviceTickets.Object);
+            var authenticationTicket = new AuthenticationTicket(
+                new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.Name, Guid.NewGuid().ToString())
+                })), "TEST");
+
+            // Act
+            var actual = await tickets.StoreAsync(authenticationTicket);
+
+            // Assert
+            Assert.NotNull(actual);
+            serviceTickets.Verify();
+        }
+
+        [Fact]
+        public async Task StoreClaimsPrincipalWithServiceTicket_ShouldReturnAsKey()
+        {
+            // Arrange
+            var expected = Guid.NewGuid().ToString();
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            serviceTickets.Setup(x => x.StoreAsync(It.IsAny<ServiceTicket>()))
+                .ReturnsAsync(expected).Verifiable();
+            var tickets = new TicketStoreWrapper(serviceTickets.Object);
+            var authenticationTicket = new AuthenticationTicket(
+                new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.Name, Guid.NewGuid().ToString())
+                })), "TEST");
+            authenticationTicket.Properties.SetServiceTicket(expected);
+
+            // Act
+            var actual = await tickets.StoreAsync(authenticationTicket);
+
+            // Assert
+            Assert.Equal(expected, actual);
+            serviceTickets.Verify();
+        }
+
+        [Fact]
+        public async Task RetrieveInvalidKey_ShouldReturnNull()
+        {
+            // Arrange
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            serviceTickets.Setup(x => x.RetrieveAsync(It.IsAny<string>()))
+                .ReturnsAsync((ServiceTicket?)null).Verifiable();
+            var tickets = new TicketStoreWrapper(serviceTickets.Object);
+
+            // Act
+            var actual = await tickets.RetrieveAsync(Guid.NewGuid().ToString());
+
+            // Assert
+            Assert.Null(actual);
+            serviceTickets.Verify();
+        }
+
+        [Fact]
+        public async Task RetrieveValidKey_ShouldReturnAuthenticationTicket()
+        {
+            // Arrange
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            var store = new Dictionary<string, ServiceTicket>();
+            serviceTickets.Setup(x => x.StoreAsync(It.IsAny<ServiceTicket>()))
+                .Callback<ServiceTicket>(x =>
+                {
+                    store[x.TicketId] = x;
+                })
+                .Returns<ServiceTicket>(ticket => Task.FromResult(ticket.TicketId)).Verifiable();
+            serviceTickets.Setup(x => x.RetrieveAsync(It.IsAny<string>()))
+                .Returns<string>(key => Task.FromResult(store.TryGetValue(key, out var ticket) ? ticket : null))
+                .Verifiable();
+            var tickets = new TicketStoreWrapper(serviceTickets.Object);
+            var expected = new AuthenticationTicket(
+                new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.Name, Guid.NewGuid().ToString())
+                })), "TEST");
+            var key = await tickets.StoreAsync(expected);
+
+            // Act
+            var actual = await tickets.RetrieveAsync(key);
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.Equal(expected.AuthenticationScheme, actual?.AuthenticationScheme);
+            Assert.Equal(expected.Principal.GetPrincipalName(), actual?.Principal.GetPrincipalName());
+            serviceTickets.Verify();
+        }
+
+        [Fact]
+        public async Task RenewAuthenticationTicket_ShouldReplaceIt()
+        {
+            // Arrange
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            var store = new Dictionary<string, ServiceTicket>();
+            serviceTickets.Setup(x => x.StoreAsync(It.IsAny<ServiceTicket>()))
+                .Callback<ServiceTicket>(x =>
+                {
+                    store[x.TicketId] = x;
+                })
+                .Returns<ServiceTicket>(ticket => Task.FromResult(ticket.TicketId)).Verifiable();
+            serviceTickets.Setup(x => x.RenewAsync(It.IsAny<string>(), It.IsAny<ServiceTicket>()))
+                .Callback<string, ServiceTicket>((key, x) =>
+                {
+                    store[key] = x;
+                }).Returns(Task.CompletedTask).Verifiable();
+            serviceTickets.Setup(x => x.RetrieveAsync(It.IsAny<string>()))
+                .Returns<string>(key => Task.FromResult(store.TryGetValue(key, out var ticket) ? ticket : null))
+                .Verifiable();
+            var tickets = new TicketStoreWrapper(serviceTickets.Object);
+            var key = await tickets.StoreAsync(
+                new AuthenticationTicket(new GenericPrincipal(new GenericIdentity("TEST"), new[] { "TEST" }), "OLD"));
+            var expected = new AuthenticationTicket(
+                new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.Name, Guid.NewGuid().ToString())
+                })), "NEW");
+
+            // Act
+            await tickets.RenewAsync(key, expected);
+
+            // Assert
+            var actual = await tickets.RetrieveAsync(key);
+            Assert.NotNull(actual);
+            Assert.Equal(expected.AuthenticationScheme, actual?.AuthenticationScheme);
+            Assert.Equal(expected.Principal.GetPrincipalName(), actual?.Principal.GetPrincipalName());
+            serviceTickets.Verify();
+        }
+
+        [Fact]
+        public async Task RemoveValidKey_ShouldSuccess()
+        {
+            // Arrange
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            // ReSharper disable once CollectionNeverQueried.Local
+            var store = new Dictionary<string, ServiceTicket>();
+            serviceTickets.Setup(x => x.StoreAsync(It.IsAny<ServiceTicket>()))
+                .Callback<ServiceTicket>(x =>
+                {
+                    store[x.TicketId] = x;
+                })
+                .Returns<ServiceTicket>(ticket => Task.FromResult(ticket.TicketId)).Verifiable();
+            serviceTickets.Setup(x => x.RemoveAsync(It.IsAny<string>()))
+                .Callback<string>(key => store.Remove(key))
+                .Returns(Task.CompletedTask).Verifiable();
+            var tickets = new TicketStoreWrapper(serviceTickets.Object);
+            var key = await tickets.StoreAsync(new AuthenticationTicket(
+                new ClaimsPrincipal(new ClaimsIdentity(new[]
+                {
+                    new Claim(ClaimTypes.Name, Guid.NewGuid().ToString())
+                })), "TEST"));
+
+            // Act
+            await tickets.RemoveAsync(key);
+
+            // Assert
+            var actual = await tickets.RetrieveAsync(key);
+            Assert.Null(actual);
+            serviceTickets.Verify();
+        }
+    }
+}

--- a/test/GSS.Authentication.CAS.Owin.Tests/AuthenticationSessionStoreWrapperTests.cs
+++ b/test/GSS.Authentication.CAS.Owin.Tests/AuthenticationSessionStoreWrapperTests.cs
@@ -1,0 +1,183 @@
+using System.Security.Claims;
+using System.Security.Principal;
+using Microsoft.Owin.Security;
+using Moq;
+using Xunit;
+
+namespace GSS.Authentication.CAS.Owin.Tests
+{
+    public class AuthenticationSessionStoreWrapperTests
+    {
+        [Fact]
+        public async Task StoreGenericPrincipal_ShouldNotThrows()
+        {
+            // Arrange
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            serviceTickets.Setup(x => x.StoreAsync(It.IsAny<ServiceTicket>()))
+                .Returns<ServiceTicket>(ticket => Task.FromResult(ticket.TicketId)).Verifiable();
+            var tickets = new AuthenticationSessionStoreWrapper(serviceTickets.Object);
+            var authenticationTicket =
+                new AuthenticationTicket(new GenericIdentity("TEST", "TEST"), null);
+
+            // Act
+            var actual = await tickets.StoreAsync(authenticationTicket);
+
+            // Assert
+            Assert.NotNull(actual);
+            serviceTickets.Verify();
+        }
+
+        [Fact]
+        public async Task StoreClaimsIdentity_ShouldNotThrows()
+        {
+            // Arrange
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            serviceTickets.Setup(x => x.StoreAsync(It.IsAny<ServiceTicket>()))
+                .Returns<ServiceTicket>(ticket => Task.FromResult(ticket.TicketId)).Verifiable();
+            var tickets = new AuthenticationSessionStoreWrapper(serviceTickets.Object);
+            var authenticationTicket = new AuthenticationTicket(
+                new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, Guid.NewGuid().ToString()) }, "TEST"), null);
+
+            // Act
+            var actual = await tickets.StoreAsync(authenticationTicket);
+
+            // Assert
+            Assert.NotNull(actual);
+            serviceTickets.Verify();
+        }
+
+        [Fact]
+        public async Task StoreClaimsPrincipalWithServiceTicket_ShouldReturnAsKey()
+        {
+            // Arrange
+            var expected = Guid.NewGuid().ToString();
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            serviceTickets.Setup(x => x.StoreAsync(It.IsAny<ServiceTicket>()))
+                .ReturnsAsync(expected).Verifiable();
+            var tickets = new AuthenticationSessionStoreWrapper(serviceTickets.Object);
+            var authenticationTicket = new AuthenticationTicket(
+                new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, Guid.NewGuid().ToString()) }, "TEST"), null);
+            authenticationTicket.Properties.SetServiceTicket(expected);
+
+            // Act
+            var actual = await tickets.StoreAsync(authenticationTicket);
+
+            // Assert
+            Assert.Equal(expected, actual);
+            serviceTickets.Verify();
+        }
+
+        [Fact]
+        public async Task RetrieveInvalidKey_ShouldReturnNull()
+        {
+            // Arrange
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            serviceTickets.Setup(x => x.RetrieveAsync(It.IsAny<string>()))
+                .ReturnsAsync((ServiceTicket?)null).Verifiable();
+            var tickets = new AuthenticationSessionStoreWrapper(serviceTickets.Object);
+
+            // Act
+            var actual = await tickets.RetrieveAsync(Guid.NewGuid().ToString());
+
+            // Assert
+            Assert.Null(actual);
+            serviceTickets.Verify();
+        }
+
+        [Fact]
+        public async Task RetrieveValidKey_ShouldReturnAuthenticationTicket()
+        {
+            // Arrange
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            var store = new Dictionary<string, ServiceTicket>();
+            serviceTickets.Setup(x => x.StoreAsync(It.IsAny<ServiceTicket>()))
+                .Callback<ServiceTicket>(x =>
+                {
+                    store[x.TicketId] = x;
+                })
+                .Returns<ServiceTicket>(ticket => Task.FromResult(ticket.TicketId)).Verifiable();
+            serviceTickets.Setup(x => x.RetrieveAsync(It.IsAny<string>()))
+                .Returns<string>(key => Task.FromResult(store.TryGetValue(key, out var ticket) ? ticket : null))
+                .Verifiable();
+            var tickets = new AuthenticationSessionStoreWrapper(serviceTickets.Object);
+            var expected = new AuthenticationTicket(
+                new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, Guid.NewGuid().ToString()) }, "TEST"), null);
+            var key = await tickets.StoreAsync(expected);
+
+            // Act
+            var actual = await tickets.RetrieveAsync(key);
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.Equal(expected.Identity.AuthenticationType, actual?.Identity.AuthenticationType);
+            Assert.Equal(expected.Identity.GetPrincipalName(), actual?.Identity.GetPrincipalName());
+            serviceTickets.Verify();
+        }
+
+        [Fact]
+        public async Task RenewAuthenticationTicket_ShouldReplaceIt()
+        {
+            // Arrange
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            var store = new Dictionary<string, ServiceTicket>();
+            serviceTickets.Setup(x => x.StoreAsync(It.IsAny<ServiceTicket>()))
+                .Callback<ServiceTicket>(x =>
+                {
+                    store[x.TicketId] = x;
+                })
+                .Returns<ServiceTicket>(ticket => Task.FromResult(ticket.TicketId)).Verifiable();
+            serviceTickets.Setup(x => x.RenewAsync(It.IsAny<string>(), It.IsAny<ServiceTicket>()))
+                .Callback<string, ServiceTicket>((key, x) =>
+                {
+                    store[key] = x;
+                }).Returns(Task.CompletedTask).Verifiable();
+            serviceTickets.Setup(x => x.RetrieveAsync(It.IsAny<string>()))
+                .Returns<string>(key => Task.FromResult(store.TryGetValue(key, out var ticket) ? ticket : null))
+                .Verifiable();
+            var tickets = new AuthenticationSessionStoreWrapper(serviceTickets.Object);
+            var key = await tickets.StoreAsync(
+                new AuthenticationTicket(new GenericIdentity("TEST", "OLD"), null));
+            var expected = new AuthenticationTicket(
+                new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, Guid.NewGuid().ToString()) }, "NEW"), null);
+
+            // Act
+            await tickets.RenewAsync(key, expected);
+
+            // Assert
+            var actual = await tickets.RetrieveAsync(key);
+            Assert.NotNull(actual);
+            Assert.Equal(expected.Identity.AuthenticationType, actual?.Identity.AuthenticationType);
+            Assert.Equal(expected.Identity.GetPrincipalName(), actual?.Identity.GetPrincipalName());
+            serviceTickets.Verify();
+        }
+
+        [Fact]
+        public async Task RemoveValidKey_ShouldSuccess()
+        {
+            // Arrange
+            var serviceTickets = new Mock<IServiceTicketStore>();
+            // ReSharper disable once CollectionNeverQueried.Local
+            var store = new Dictionary<string, ServiceTicket>();
+            serviceTickets.Setup(x => x.StoreAsync(It.IsAny<ServiceTicket>()))
+                .Callback<ServiceTicket>(x =>
+                {
+                    store[x.TicketId] = x;
+                })
+                .Returns<ServiceTicket>(ticket => Task.FromResult(ticket.TicketId)).Verifiable();
+            serviceTickets.Setup(x => x.RemoveAsync(It.IsAny<string>()))
+                .Callback<string>(key => store.Remove(key))
+                .Returns(Task.CompletedTask).Verifiable();
+            var tickets = new AuthenticationSessionStoreWrapper(serviceTickets.Object);
+            var key = await tickets.StoreAsync(new AuthenticationTicket(
+                new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, Guid.NewGuid().ToString()) }, "TEST"), null));
+
+            // Act
+            await tickets.RemoveAsync(key);
+
+            // Assert
+            var actual = await tickets.RetrieveAsync(key);
+            Assert.Null(actual);
+            serviceTickets.Verify();
+        }
+    }
+}


### PR DESCRIPTION
- Removed Assertion from ServiceTicket
- Avoid ArgumentNullException for SLO with OpenID Connect Authentication
- Introduce the DistributedCacheServiceTicketStoreOptions
- Added OpenID Connect Authentication method samples
- Renamed the UseAuthenticationSessionStore to SaveTokens