### PR TITLE
Remove the `netstandard2.0` target framework from `GSS.Authentication.CAS.AspNetCore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.3.1 (2022-08-18)
+
+- Remove the `netstandard2.0` target framework from `GSS.Authentication.CAS.AspNetCore` to fix [CVE-2022-34716](https://github.com/advisories/GHSA-2m65-m22p-9wjw)
+
 ## 5.3.0 (2022-04-21)
 
 - [Use the ASP.NET Core shared framework](https://docs.microsoft.com/aspnet/core/fundamentals/target-aspnetcore#use-the-aspnet-core-shared-framework) [#131](https://github.com/akunzai/GSS.Authentication.CAS/pull/131)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
-    <Version>5.3.0</Version>
+    <Version>5.3.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release' ">

--- a/src/GSS.Authentication.CAS.AspNetCore/GSS.Authentication.CAS.AspNetCore.csproj
+++ b/src/GSS.Authentication.CAS.AspNetCore/GSS.Authentication.CAS.AspNetCore.csproj
@@ -1,13 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Description>ASP.NET Core Middlewares for CAS Authentication</Description>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\GSS.Authentication.CAS.Core\GSS.Authentication.CAS.Core.csproj" />


### PR DESCRIPTION
- https://github.com/advisories/GHSA-2m65-m22p-9wjw