### PR TITLE
Assign the minimum required access to workflow jobs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,8 @@ on:
     tags:
       - "*"
 
+permissions: read-all
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
- https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs