### PR TITLE
The `System.Drawing.Common` before 4.7.2 is vulnerable

### DIFF
--- a/samples/AspNetCoreSingleLogoutSample/AspNetCoreSingleLogoutSample.csproj
+++ b/samples/AspNetCoreSingleLogoutSample/AspNetCoreSingleLogoutSample.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.10" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="6.0.10" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="5.1.5" />
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- https://github.com/advisories/GHSA-rxg9-xrhp-64gj