### PR TITLE
.NET Core 3.1 reach EOL since 2022-12-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: |
-            3.1.x
             6.0.x
       - name: Set up MSBuild
         if: matrix.os == 'windows-latest'

--- a/test/GSS.Authentication.CAS.Core.Tests/GSS.Authentication.CAS.Core.Tests.csproj
+++ b/test/GSS.Authentication.CAS.Core.Tests/GSS.Authentication.CAS.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/GSS.Authentication.CAS.DistributedCache.Tests/GSS.Authentication.CAS.DistributedCache.Tests.csproj
+++ b/test/GSS.Authentication.CAS.DistributedCache.Tests/GSS.Authentication.CAS.DistributedCache.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net48</TargetFrameworks>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">

--- a/test/GSS.Authentication.CAS.Testing/GSS.Authentication.CAS.Testing.csproj
+++ b/test/GSS.Authentication.CAS.Testing/GSS.Authentication.CAS.Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' ">


### PR DESCRIPTION
- https://devblogs.microsoft.com/dotnet/net-core-3-1-will-reach-end-of-support-on-december-13-2022/