### PR TITLE
Avoid linux test fails on .NET SDK 6.0.413

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,11 @@ jobs:
       - name: Set up .NET SDK
         uses: actions/setup-dotnet@v3
         with:
+          # Workaround for https://github.com/microsoft/vstest/issues/4549
           dotnet-version: |
-            6.0.x
+            6.0.316
+      - name: Set up .NET SDK version
+        run: dotnet new globaljson --sdk-version 6.0.316
       - name: Set up MSBuild
         if: matrix.os == 'windows-latest'
         uses: microsoft/setup-msbuild@v1


### PR DESCRIPTION
- https://github.com/microsoft/vstest/issues/4549