### PR TITLE
The `ISystemClock` is obsolete since ASP.NET Core 8.0

### DIFF
--- a/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs
@@ -12,11 +12,18 @@ namespace GSS.Authentication.CAS.AspNetCore;
 public class CasAuthenticationHandler<TOptions> : RemoteAuthenticationHandler<TOptions>
     where TOptions : CasAuthenticationOptions, new()
 {
+#if NET8_0_OR_GREATER
+    public CasAuthenticationHandler(IOptionsMonitor<TOptions> options, ILoggerFactory logger, UrlEncoder encoder)
+        : base(options, logger, encoder)
+    {
+    }
+#else
     public CasAuthenticationHandler(IOptionsMonitor<TOptions> options, ILoggerFactory logger, UrlEncoder encoder,
         ISystemClock clock)
         : base(options, logger, encoder, clock)
     {
     }
+#endif
 
     protected new CasEvents Events
     {

--- a/src/GSS.Authentication.CAS.AspNetCore/GSS.Authentication.CAS.AspNetCore.csproj
+++ b/src/GSS.Authentication.CAS.AspNetCore/GSS.Authentication.CAS.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
     <Description>ASP.NET Core Middlewares for CAS Authentication</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
- https://learn.microsoft.com/dotnet/core/compatibility/aspnet-core/8.0/isystemclock-obsolete