### PR TITLE
Bump Keycloak version from 23.0.0 to 23.0.2

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # https://www.keycloak.org/server/containers
-ARG KEYCLOAK_VERSION=23.0.0
+ARG KEYCLOAK_VERSION=23.0.2
 
 FROM alpine as downloader
 ARG KEYCLOAK_VERSION


### PR DESCRIPTION
- https://www.keycloak.org/2023/12/keycloak-2302-released.html