### PR TITLE
Bump Keycloak version from 23.0.2 to 23.0.3

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # https://www.keycloak.org/server/containers
-ARG KEYCLOAK_VERSION=23.0.2
+ARG KEYCLOAK_VERSION=23.0.3
 
 FROM alpine as downloader
 ARG KEYCLOAK_VERSION

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
           pnpm install
           pnpm lint
           pnpm build
+      - name: Build docker images
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cd .devcontainer
+          docker compose build
       - name: Test
         run: |
           dotnet test --collect:"XPlat Code Coverage"


### PR DESCRIPTION
- https://github.com/keycloak/keycloak/releases/tag/23.0.3