### PR TITLE
`MapFallbackToFile()` only match `GET` and `HEAD` requests by default

### DIFF
--- a/samples/AspNetCoreReactSample/Program.cs
+++ b/samples/AspNetCoreReactSample/Program.cs
@@ -146,10 +146,7 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
-app.MapFallbackToFile("index.html").AllowAnonymous()
-    // only match 'GET' and 'HEAD' requests, fixed since .NET 7
-    // https://github.com/aspnet/Announcements/issues/495
-    .WithMetadata(new HttpMethodMetadata(new[] { HttpMethod.Get.Method, HttpMethod.Head.Method }));
+app.MapFallbackToFile("index.html").AllowAnonymous();
 
 try
 {


### PR DESCRIPTION
- https://github.com/aspnet/Announcements/issues/495