### PR TITLE
Bump keycloak version from 23.0.5 to 23.0.6

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # https://www.keycloak.org/server/containers
-ARG KEYCLOAK_VERSION=23.0.5
+ARG KEYCLOAK_VERSION=23.0.6
 
 FROM alpine as downloader
 ARG KEYCLOAK_VERSION


### PR DESCRIPTION
- https://github.com/keycloak/keycloak/releases/tag/23.0.6