### PR TITLE
Top-level version property in docker compose is obsolete

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,4 +1,3 @@
-version: '2'
 name: auth-cas_devcontainer
 services:
   dotnet:


### PR DESCRIPTION
- https://docs.docker.com/compose/compose-file/04-version-and-name/