### PR TITLE
Bump keycloak from 26.0.1 to 26.0.2

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,5 +1,5 @@
 # https://www.keycloak.org/server/containers
-ARG KEYCLOAK_VERSION=26.0.1
+ARG KEYCLOAK_VERSION=26.0.2
 
 # https://github.com/keycloak/keycloak/tree/main/quarkus/container
 # https://quay.io/repository/keycloak/keycloak?tab=tags


### PR DESCRIPTION
- https://github.com/keycloak/keycloak/releases/tag/26.0.2