### PR TITLE
The environment variables `KEYCLOAK_ADMIN` have been deprecated

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -23,8 +23,8 @@ services:
     image: keycloak:cas
     environment:
       # https://www.keycloak.org/server/configuration
-      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN:-admin}
-      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD:-admin}
+      KC_BOOTSTRAP_ADMIN_USERNAME: ${KC_BOOTSTRAP_ADMIN_USERNAME:-admin}
+      KC_BOOTSTRAP_ADMIN_PASSWORD: ${KC_BOOTSTRAP_ADMIN_PASSWORD:-admin}
       # https://www.keycloak.org/server/reverseproxy
       KC_PROXY_HEADERS: xforwarded
     volumes:


### PR DESCRIPTION
- https://www.keycloak.org/docs/latest/upgrading/index.html#admin-bootstrapping-and-recovery