### PR TITLE
build: upgrade devcontainer SDK to .NET 10 & add net10.0 target to AspNetCore

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS dotnet-lts-runtime
 
 # https://hub.docker.com/_/microsoft-dotnet-sdk/
 # Using Debian-based image for better Playwright browser support
-FROM mcr.microsoft.com/dotnet/sdk:9.0
+FROM mcr.microsoft.com/dotnet/sdk:10.0
 
 # install ASP.NET Core 8.0 Runtime
 COPY --from=dotnet-lts-runtime /usr/share/dotnet /usr/share/dotnet
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxfixes3 \
     libxrandr2 \
     libgbm1 \
-    libasound2 \
+    libasound2t64 \
     libpango-1.0-0 \
     libcairo2 \
     libatspi2.0-0 \

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -11,7 +11,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
-    <Version>5.6.1</Version>
+    <Version>5.7.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release' ">

--- a/src/GSS.Authentication.CAS.AspNetCore/GSS.Authentication.CAS.AspNetCore.csproj
+++ b/src/GSS.Authentication.CAS.AspNetCore/GSS.Authentication.CAS.AspNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net8.0;net10.0</TargetFrameworks>
     <Description>ASP.NET Core Middlewares for CAS Authentication</Description>
   </PropertyGroup>
 


### PR DESCRIPTION
This PR upgrades the devcontainer SDK environment to .NET 10 and multi-targets GSS.Authentication.CAS.AspNetCore to natively support net10.0, preparing for the EOL of .NET 8/9 in November 2026.