### PR TITLE
deps: bump test dependencies and unify pnpm version in React sample

### DIFF
--- a/.github/workflows/build-react-sample-client.yml
+++ b/.github/workflows/build-react-sample-client.yml
@@ -19,18 +19,28 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Install pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10
-          run_install: false
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'pnpm'
-          cache-dependency-path: 'samples/AspNetCoreReactSample/ClientApp/pnpm-lock.yaml'
+
+      - name: Prepare pnpm and get store path
+        id: pnpm-cache
+        shell: bash
+        working-directory: samples/AspNetCoreReactSample/ClientApp
+        run: |
+          corepack enable
+          corepack prepare
+          echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('samples/AspNetCoreReactSample/ClientApp/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -160,20 +160,30 @@ jobs:
           cache: true
           cache-dependency-path: '**/Directory.Packages.props'
 
-      - name: Install pnpm
-        if: steps.check.outputs.run == 'true' && matrix.name == 'React'
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10
-          run_install: false
-
       - name: Set up Node.js
         if: steps.check.outputs.run == 'true' && matrix.name == 'React'
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: 'pnpm'
-          cache-dependency-path: 'samples/AspNetCoreReactSample/ClientApp/pnpm-lock.yaml'
+
+      - name: Prepare pnpm and get store path
+        if: steps.check.outputs.run == 'true' && matrix.name == 'React'
+        id: pnpm-cache
+        shell: bash
+        working-directory: samples/AspNetCoreReactSample/ClientApp
+        run: |
+          corepack enable
+          corepack prepare
+          echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm cache
+        if: steps.check.outputs.run == 'true' && matrix.name == 'React'
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('samples/AspNetCoreReactSample/ClientApp/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
         if: steps.check.outputs.run == 'true' && matrix.name == 'React'

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,13 +42,13 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageVersion Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <PackageVersion Include="Microsoft.Owin.Host.SystemWeb" Version="4.2.3" />
     <PackageVersion Include="Microsoft.Owin.Security.Cookies" Version="4.2.3" />
     <PackageVersion Include="Microsoft.Owin.Security.OpenIdConnect" Version="4.2.3" />
     <PackageVersion Include="Microsoft.Owin.Testing" Version="4.2.3" />
-    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.5.1" />
+    <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="18.6.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="MSBuild.Microsoft.VisualStudio.Web.targets" Version="14.0.0.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
@@ -60,8 +60,8 @@
     <PackageVersion Include="Sustainsys.Saml2.Owin" Version="2.11.0" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageVersion Include="Microsoft.Playwright" Version="1.59.0" />
-    <PackageVersion Include="Microsoft.Playwright.Xunit" Version="1.59.0" />
+    <PackageVersion Include="Microsoft.Playwright" Version="1.60.0" />
+    <PackageVersion Include="Microsoft.Playwright.Xunit" Version="1.60.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>

--- a/samples/AspNetCoreReactSample/ClientApp/package.json
+++ b/samples/AspNetCoreReactSample/ClientApp/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "private": true,
-  "packageManager": "pnpm@11.2.0",
+  "packageManager": "pnpm@11.4.0",
   "scripts": {
     "prestart": "node aspnetcore-https && node aspnetcore-react",
     "start": "vite",


### PR DESCRIPTION
## Summary

This PR executes dependency upgrade preparation for the upcoming v5.7.0 release.

### Changes by scope

**deps**
- Bump `Microsoft.NET.Test.Sdk` and `Microsoft.TestPlatform.ObjectModel` to 18.6.0
- Bump `Microsoft.Playwright` and `Microsoft.Playwright.Xunit` to 1.60.0

**ci**
- Bump React sample pnpm to **11.4.0**
- Unify pnpm version sourcing: workflows now read the version from `package.json` `packageManager` field instead of hardcoding it. Future pnpm bumps only need to change one place.