### PR TITLE
fix(react-sample): retry fetching auth schemes on transient proxy failures

### DIFF
--- a/samples/AspNetCoreReactSample/ClientApp/src/components/Login.tsx
+++ b/samples/AspNetCoreReactSample/ClientApp/src/components/Login.tsx
@@ -1,12 +1,34 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { UserManager } from '../api';
 
+const MAX_RETRIES = 5;
+const RETRY_DELAY_MS = 1000;
+
 export function Login(): React.JSX.Element {
   const userManager = useMemo(() => new UserManager(), []);
   const [schemes, setSchemes] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
 
   const fetchSchemes = useCallback(async () => {
-    setSchemes(await userManager.getAuthenticationSchemes());
+    setLoading(true);
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        const result = await userManager.getAuthenticationSchemes();
+        if (result && result.length > 0) {
+          setSchemes(result);
+          setLoading(false);
+          return;
+        }
+      } catch {
+        // Transient error (e.g. proxy not ready yet), retry
+      }
+      if (attempt < MAX_RETRIES - 1) {
+        await new Promise((resolve) =>
+          setTimeout(resolve, RETRY_DELAY_MS * (attempt + 1))
+        );
+      }
+    }
+    setLoading(false);
   }, [userManager]);
 
   useEffect(() => {
@@ -16,16 +38,20 @@ export function Login(): React.JSX.Element {
   return (
     <>
       <h1>Choose an authentication scheme</h1>
-      {schemes.map((scheme) => (
-        <button
-          key={scheme}
-          type="button"
-          className="btn btn-outline-primary btn-lg mx-1"
-          onClick={() => userManager.signIn(scheme)}
-        >
-          {scheme}
-        </button>
-      ))}
+      {loading ? (
+        <p>Loading...</p>
+      ) : (
+        schemes.map((scheme) => (
+          <button
+            key={scheme}
+            type="button"
+            className="btn btn-outline-primary btn-lg mx-1"
+            onClick={() => userManager.signIn(scheme)}
+          >
+            {scheme}
+          </button>
+        ))
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Problem

In CI environments with Vite 8 (Rolldown), the React E2E tests were timing out because the CAS button on the login page was never rendered.

**Root cause:** `Login.tsx`'s `fetchSchemes()` had no error handling or retry logic. When `/api/account/auth-schemes` failed due to a transient error (e.g. Vite proxy race condition during SPA startup, Vite 8's new 408 timeout behavior), `schemes` stayed as `[]` and no login buttons appeared.

This was reproducible on CI with Vite 8 because:
1. Vite 8 uses Rolldown for bundling - first module transformation is slower
2. Vite 8.0.15 added `send 408 on request timeout` which changed proxy behavior
3. The first API call to auth-schemes could fail during the SPA proxy startup race window

## Fix

Added retry logic with linear backoff (up to 5 retries, 1-5 second delays) to `fetchSchemes()`. Also added a `loading` state for better UX.

## Test

React E2E tests that were failing:
- `Logout_ReturnsToAnonymousState` 
- `FullLoginFlow_WithCas_ShowsUserInfo`
- `AuthenticatedUser_StaysLoggedIn_AfterNavigation`
- `LoginPage_ShowsAuthenticationSchemes`

Observed in: runs/26799521816/job/79003002260?pr=930