### PR TITLE
Group React dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,14 @@ updates:
       interval: monthly
     cooldown:
       default-days: 3
+    groups:
+      react:
+        patterns:
+          - react
+          - react-dom
+          - '@types/react'
+          - '@types/react-dom'
+          - '@vitejs/plugin-react'
   - package-ecosystem: nuget
     directory: /
     schedule:

--- a/samples/AspNetCoreReactSample/ClientApp/src/components/Login.tsx
+++ b/samples/AspNetCoreReactSample/ClientApp/src/components/Login.tsx
@@ -1,34 +1,12 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { UserManager } from '../api';
 
-const MAX_RETRIES = 5;
-const RETRY_DELAY_MS = 1000;
-
 export function Login(): React.JSX.Element {
   const userManager = useMemo(() => new UserManager(), []);
   const [schemes, setSchemes] = useState<string[]>([]);
-  const [loading, setLoading] = useState(true);
 
   const fetchSchemes = useCallback(async () => {
-    setLoading(true);
-    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-      try {
-        const result = await userManager.getAuthenticationSchemes();
-        if (result && result.length > 0) {
-          setSchemes(result);
-          setLoading(false);
-          return;
-        }
-      } catch {
-        // Transient error (e.g. proxy not ready yet), retry
-      }
-      if (attempt < MAX_RETRIES - 1) {
-        await new Promise((resolve) =>
-          setTimeout(resolve, RETRY_DELAY_MS * (attempt + 1))
-        );
-      }
-    }
-    setLoading(false);
+    setSchemes(await userManager.getAuthenticationSchemes());
   }, [userManager]);
 
   useEffect(() => {
@@ -38,20 +16,16 @@ export function Login(): React.JSX.Element {
   return (
     <>
       <h1>Choose an authentication scheme</h1>
-      {loading ? (
-        <p>Loading...</p>
-      ) : (
-        schemes.map((scheme) => (
-          <button
-            key={scheme}
-            type="button"
-            className="btn btn-outline-primary btn-lg mx-1"
-            onClick={() => userManager.signIn(scheme)}
-          >
-            {scheme}
-          </button>
-        ))
-      )}
+      {schemes.map((scheme) => (
+        <button
+          key={scheme}
+          type="button"
+          className="btn btn-outline-primary btn-lg mx-1"
+          onClick={() => userManager.signIn(scheme)}
+        >
+          {scheme}
+        </button>
+      ))}
     </>
   );
 }


### PR DESCRIPTION
## Summary
- group React-related npm dependencies in Dependabot so paired packages update together
- revert the React sample auth scheme retry/loading change after local E2E verification showed it is not needed

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'
- pnpm lint && pnpm build (samples/AspNetCoreReactSample/ClientApp)
- dotnet build test/GSS.Authentication.CAS.E2E.Tests
- SAMPLE_BASE_URL=https://localhost:5005 PROXY_TARGET=https://localhost:5005 dotnet test test/GSS.Authentication.CAS.E2E.Tests --logger "trx;LogFileName=test-results-React-local.trx" --filter "FullyQualifiedName~AspNetCoreReactSampleTests"