### PR TITLE
Upgrade Keycloak and CAS protocol extension to 26.6.3

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,6 +1,7 @@
-# https://github.com/keycloak/keycloak/releases
-ARG KEYCLOAK_VERSION=26.6.2
-ARG KEYCLOAK_CAS_VERSION=26.6.2
+# https://github.com/keycloak/keycloak/releases/tag/26.6.3
+ARG KEYCLOAK_VERSION=26.6.3
+# https://github.com/jacekkow/keycloak-protocol-cas/releases/tag/26.6.3
+ARG KEYCLOAK_CAS_VERSION=26.6.3
 FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION}
 ARG KEYCLOAK_VERSION
 ARG KEYCLOAK_CAS_VERSION


### PR DESCRIPTION
## Summary
Updates the Keycloak Docker image and CAS protocol extension to version 26.6.3 in the development container configuration.

## Changes
- Bumped `KEYCLOAK_VERSION` from 26.6.2 to 26.6.3
- Bumped `KEYCLOAK_CAS_VERSION` from 26.6.2 to 26.6.3
- Added explicit release tag references in comments for both Keycloak and keycloak-protocol-cas to improve traceability

## Details
This update ensures the E2E test environment uses the latest patch release of Keycloak and its CAS protocol extension, maintaining consistency between the two components and picking up any bug fixes or security patches included in 26.6.3.

https://claude.ai/code/session_01CrgUnZWwFMRJB4DTquy4n3