### PR TITLE
docs: add open source community health files and enable XML docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for everything in the repository
+* @akunzai

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+# Pull Request
+
+## Description
+
+<!-- What does this PR do? Link to related issue if applicable (e.g. Fixes #123) -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change (requires major version bump)
+- [ ] Refactoring / maintenance
+- [ ] Documentation update
+- [ ] Dependency update
+- [ ] CI/CD change
+
+## Checklist
+
+- [ ] I have applied an appropriate **PR label** (required for release notes)
+- [ ] `dotnet build -c Release` passes with no warnings
+- [ ] `dotnet test --filter "FullyQualifiedName!~E2E"` passes
+- [ ] Added or updated tests for behavior changes
+- [ ] Public API changes include XML documentation comments

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+| Version       | Supported          |
+| ------------- | ------------------ |
+| Latest        | :white_check_mark: |
+| < Latest - 1  | :x:                |
+
+Only the latest major version receives security patches.
+
+## Reporting a Vulnerability
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+Use [GitHub Private Vulnerability Reporting](https://github.com/akunzai/GSS.Authentication.CAS/security/advisories/new) to submit a report confidentially.
+
+Please include:
+
+- A description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Suggested fix (if any)
+
+We will acknowledge receipt within **7 business days** and aim to release a patch within **30 days** of confirmation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to GSS.Authentication.CAS
+
+Thank you for your interest in contributing! This guide covers how to report issues, propose features, and submit pull requests.
+
+## Reporting Issues
+
+- **Security vulnerabilities:** See [SECURITY.md](.github/SECURITY.md). Do **not** open public issues.
+- **Bugs:** Use the [Bug Report](.github/ISSUE_TEMPLATE/bug_report.md) issue template.
+- **Feature requests:** Use the [Feature Request](.github/ISSUE_TEMPLATE/feature_request.md) issue template.
+
+## Development Setup
+
+### Prerequisites
+
+- [.NET SDK 8.0+](https://dot.net) (10.0 recommended)
+- [Docker](https://www.docker.com/) (for E2E tests with Keycloak)
+
+### Clone & Build
+
+```shell
+git clone https://github.com/akunzai/GSS.Authentication.CAS.git
+cd GSS.Authentication.CAS
+dotnet build
+```
+
+### Running Tests
+
+```shell
+# Unit + integration tests (no external dependencies)
+dotnet test --filter "FullyQualifiedName!~E2E"
+
+# With code coverage report
+dotnet test --collect:"XPlat Code Coverage" --filter "FullyQualifiedName!~E2E"
+dotnet tool restore && dotnet tool run reportgenerator
+
+# E2E tests (requires Keycloak — see .devcontainer/)
+dotnet test --filter "FullyQualifiedName~E2E"
+```
+
+### Dev Container (recommended)
+
+Open in VS Code with the [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension. Keycloak is started automatically.
+
+## Submitting a Pull Request
+
+1. **Fork** the repository and create a branch from `main`:
+
+   ```shell
+   git checkout -b fix/your-bug-description
+   ```
+
+2. **Make your changes.** Follow the [code conventions](.editorconfig).
+
+3. **Run tests** before pushing:
+
+   ```shell
+   dotnet build -c Release
+   dotnet test --filter "FullyQualifiedName!~E2E"
+   ```
+
+4. **Apply a label** to your PR (required for release-drafter to categorize it):
+
+   | Label                      | When to use              |
+   | -------------------------- | ------------------------ |
+   | `breaking`                 | Breaking API change      |
+   | `feature` / `enhancement`  | New functionality        |
+   | `bug` / `fix`              | Bug fix                  |
+   | `chore` / `refactor`       | Internal cleanup         |
+   | `dependencies`             | Dependency updates       |
+   | `documentation`            | Docs only                |
+   | `ignore-for-release`       | Not noteworthy for users |
+
+5. **Open a PR** against `main`. Fill in the PR template.
+
+## Code Conventions
+
+- 4-space indentation for C# (enforced via `.editorconfig`)
+- Nullable reference types enabled — avoid `!` suppression unless justified
+- `TreatWarningsAsErrors` is on — zero warnings policy
+- Private fields: `_camelCase`; constants/statics: `PascalCase`
+- All public API should have XML documentation comments (`/// <summary>`)
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,12 +3,17 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <PropertyGroup>
-    <PackageTags>CAS</PackageTags>
+    <PackageTags>cas;sso;authentication;aspnetcore;owin;middleware</PackageTags>
     <PackageProjectUrl>https://github.com/akunzai/GSS.Authentication.CAS</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReleaseNotes>See https://github.com/akunzai/GSS.Authentication.CAS/releases</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- https://learn.microsoft.com/dotnet/core/project-sdk/msbuild-props#generatedocumentationfile -->
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <!-- Suppress missing XML comment warnings to allow incremental adoption -->
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
     <Version>5.7.0</Version>


### PR DESCRIPTION
## Changes

- Add `.github/SECURITY.md` with private vulnerability reporting policy (GitHub Advisory)
- Add `CONTRIBUTING.md` with development setup, test commands, PR workflow, and label guide
- Add `.github/PULL_REQUEST_TEMPLATE.md` with type-of-change checklist
- Add `.github/CODEOWNERS` for auto-review assignment
- Enable `GenerateDocumentationFile` in `src/Directory.Build.props` for NuGet XML API docs
- Expand `PackageTags` and add `PackageReleaseNotes` in `src/Directory.Build.props`

## Motivation

Based on open source best practices audit. Key gaps addressed:

| Before | After |
| ------ | ----- |
| No security disclosure channel | SECURITY.md → GitHub Private Vulnerability Reporting |
| No contributor guide | CONTRIBUTING.md with full setup + PR workflow |
| No PR template | Checklist enforcing label + build + test |
| No CODEOWNERS | Auto-assigns `@akunzai` as reviewer |
| No XML API docs in NuGet package | `GenerateDocumentationFile=true` (CS1591 suppressed for incremental adoption) |

## Verification

- `dotnet build -c Release` → ✅ 0 warnings, 0 errors
- `markdownlint-cli2` → ✅ 0 errors
- XML docs confirmed generated for all `src/` TFMs