### PR TITLE
Adopt mise toolchain and switch React sample to aube

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,6 +45,7 @@
     },
     "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers-extra/features/mise:1": {},
     "ghcr.io/devcontainers/features/git:1": {
       "version": "latest",
       "ppa": "false"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -10,6 +10,15 @@ else
 	dotnet dev-certs https --trust
 fi
 
+# Provision aube for the React sample client via mise; the version is pinned in
+# mise.toml (single source of truth), and mise fetches a checksum-verified prebuilt
+# binary, so no untrusted npm lifecycle scripts run.
+# https://aube.jdx.dev/installation
+if ! command -v aube >/dev/null 2>&1; then
+    echo "Installing aube via mise (version from mise.toml)..."
+    (cd /workspace && mise trust && mise install aube)
+fi
+
 # Install Playwright browsers for E2E testing
 # Only install if the E2E test project exists
 if [[ -f "/workspace/test/GSS.Authentication.CAS.E2E.Tests/GSS.Authentication.CAS.E2E.Tests.csproj" ]]; then

--- a/.github/workflows/build-react-sample-client.yml
+++ b/.github/workflows/build-react-sample-client.yml
@@ -16,38 +16,35 @@ permissions: read-all
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: samples/AspNetCoreReactSample/ClientApp
     steps:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v6
+      - name: Set up mise (provisions aube + node from mise.toml)
+        uses: jdx/mise-action@v4
         with:
-          node-version: 24
+          install_args: aube node
+          cache: true
 
-      - name: Prepare pnpm and get store path
-        id: pnpm-cache
-        shell: bash
-        working-directory: samples/AspNetCoreReactSample/ClientApp
-        run: |
-          corepack enable
-          corepack prepare
-          echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Get aube store path
+        id: aube-store
+        run: echo "path=$(aube store path)" >> "$GITHUB_OUTPUT"
 
-      - name: Setup pnpm cache
+      - name: Cache aube store
         uses: actions/cache@v6
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('samples/AspNetCoreReactSample/ClientApp/pnpm-lock.yaml') }}
+          path: ${{ steps.aube-store.outputs.path }}
+          key: ${{ runner.os }}-aube-store-${{ hashFiles('samples/AspNetCoreReactSample/ClientApp/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-aube-store-
 
       - name: Install dependencies
-        run: pnpm install
-        working-directory: samples/AspNetCoreReactSample/ClientApp
+        run: aube ci
 
       - name: Build
         run: |
-          pnpm lint
-          pnpm build
-        working-directory: samples/AspNetCoreReactSample/ClientApp
+          aube lint
+          aube build

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -160,34 +160,30 @@ jobs:
           cache: true
           cache-dependency-path: '**/Directory.Packages.props'
 
-      - name: Set up Node.js
+      - name: Set up mise (provisions aube + node from mise.toml)
         if: steps.check.outputs.run == 'true' && matrix.name == 'React'
-        uses: actions/setup-node@v6
+        uses: jdx/mise-action@v4
         with:
-          node-version: 24
+          install_args: aube node
+          cache: true
 
-      - name: Prepare pnpm and get store path
+      - name: Get aube store path
         if: steps.check.outputs.run == 'true' && matrix.name == 'React'
-        id: pnpm-cache
-        shell: bash
-        working-directory: samples/AspNetCoreReactSample/ClientApp
-        run: |
-          corepack enable
-          corepack prepare
-          echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+        id: aube-store
+        run: echo "path=$(aube store path)" >> "$GITHUB_OUTPUT"
 
-      - name: Setup pnpm cache
+      - name: Cache aube store
         if: steps.check.outputs.run == 'true' && matrix.name == 'React'
         uses: actions/cache@v6
         with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('samples/AspNetCoreReactSample/ClientApp/pnpm-lock.yaml') }}
+          path: ${{ steps.aube-store.outputs.path }}
+          key: ${{ runner.os }}-aube-store-${{ hashFiles('samples/AspNetCoreReactSample/ClientApp/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+            ${{ runner.os }}-aube-store-
 
       - name: Install dependencies
         if: steps.check.outputs.run == 'true' && matrix.name == 'React'
-        run: pnpm install
+        run: aube ci
         working-directory: samples/AspNetCoreReactSample/ClientApp
 
       - name: Build E2E Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,17 @@ dotnet test --filter "FullyQualifiedName~Cas20ServiceTicketValidatorTests.Valida
 cd owin && msbuild -noLogo -verbosity:minimal -restore
 
 # React sample client (in samples/AspNetCoreReactSample/ClientApp)
-pnpm lint && pnpm build
+aube lint && aube build
 ```
 
 E2E tests require a running Keycloak instance with the CAS protocol extension. See `.devcontainer/` for the Docker Compose setup.
+
+## Toolchain
+
+Developer tool versions are pinned in `mise.toml` (see [mise](https://mise.jdx.dev)) — run `mise install` to provision them:
+
+- **.NET SDK** — `global.json` pins the 10.x SDK (builds every TFM, including net8.0/netstandard2.0/netcoreapp3.1). net8.0 is installed runtime-only to *run* net8 tests/samples. net462/net48 (OWIN) are out of mise's scope (Windows + MSBuild).
+- **Node.js + [aube](https://aube.jdx.dev)** — the React sample client uses `aube` (not pnpm) for package management; it reads/writes the existing `pnpm-lock.yaml` in place. Use `aube ci` for frozen-lockfile installs.
 
 ## Architecture
 

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
+  }
+}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,14 @@
+# https://mise.jdx.dev/
+# Pins the developer toolchain so local, devcontainer, and CI environments match.
+#
+# Notes:
+# - The .NET 10 SDK builds every target framework in this repo
+#   (net10.0/net8.0/netstandard2.0/netcoreapp3.1). Only ONE SDK is needed to build.
+# - net8.0 just needs its ASP.NET Core runtime to *run* the net8 tests and samples,
+#   so it is installed runtime-only (leaner than a full net8 SDK). The major-only
+#   "8" resolves to the latest 8.0.x patch at install time.
+# - net462/net48 (OWIN) require Windows + MSBuild and are out of mise's scope.
+[tools]
+dotnet = ["10", { version = "8", runtime = "aspnetcore" }]
+node = "lts"
+aube = "1.25.1"

--- a/samples/AspNetCoreReactSample/AspNetCoreReactSample.csproj
+++ b/samples/AspNetCoreReactSample/AspNetCoreReactSample.csproj
@@ -8,7 +8,7 @@
     <IsPackable>false</IsPackable>
     <SpaRoot>ClientApp\</SpaRoot>
     <SpaProxyServerUrl>https://localhost:3000</SpaProxyServerUrl>
-    <SpaProxyLaunchCommand>pnpm start</SpaProxyLaunchCommand>
+    <SpaProxyLaunchCommand>aube start</SpaProxyLaunchCommand>
     <DefaultItemExcludes>$(DefaultItemExcludes);$(SpaRoot)node_modules\**</DefaultItemExcludes>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
@@ -45,14 +45,14 @@
       <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
     </Exec>
     <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
-    <Message Importance="high" Text="Restoring dependencies using 'pnpm'. This may take several minutes..." />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="pnpm install" />
+    <Message Importance="high" Text="Restoring dependencies using 'aube'. This may take several minutes..." />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="aube install" />
   </Target>
 
   <Target Name="PublishClientAssets" AfterTargets="ComputeFilesToPublish">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
-    <Exec WorkingDirectory="$(SpaRoot)" Command="pnpm install" />
-    <Exec WorkingDirectory="$(SpaRoot)" Command="pnpm build" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="aube install" />
+    <Exec WorkingDirectory="$(SpaRoot)" Command="aube build" />
 
     <!-- Include the newly-built files in the publish output -->
     <ItemGroup>

--- a/samples/AspNetCoreReactSample/ClientApp/README.md
+++ b/samples/AspNetCoreReactSample/ClientApp/README.md
@@ -3,19 +3,17 @@
 ## Requirement
 
 - [Node.js](https://nodejs.org)
+- [aube](https://aube.jdx.dev) (recommended via [mise](https://mise.jdx.dev): `mise install`)
 
 ## [Getting Started](https://create-react-app.dev/docs/getting-started)
 
 ```sh
-# activate the pnpm package manager
-corepack enable
-
 # install npm packages
-pnpm install
+aube install
 
 # watch and serve a dev server at https://localhost:3000/
-pnpm start
+aube start
 
 # build the project in production mode. The build artifacts will be stored in the `dist/` directory
-pnpm build
+aube build
 ```

--- a/samples/AspNetCoreReactSample/ClientApp/package.json
+++ b/samples/AspNetCoreReactSample/ClientApp/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "type": "module",
   "private": true,
-  "packageManager": "pnpm@11.8.0",
   "scripts": {
     "prestart": "node aspnetcore-https && node aspnetcore-react",
     "start": "vite",


### PR DESCRIPTION
## Summary

Adopts [mise](https://mise.jdx.dev) to pin the developer toolchain and replaces pnpm with [aube](https://aube.jdx.dev) for the React sample client.

## .NET via mise + global.json

- `mise.toml` pins the **.NET 10 SDK** + **net8 ASP.NET Core runtime** (runtime-only) + Node LTS + aube.
- Versions use floating specifiers (`10`, `8`, `lts`) so they auto-resolve to the latest patch/LTS at install time.
- `global.json` pins the .NET 10 SDK with `rollForward: latestFeature`.
- The .NET 10 SDK builds **every** TFM in the repo (net10.0/net8.0/netstandard2.0/netcoreapp3.1); net8.0 only needs its runtime to *run* net8 tests/samples, hence runtime-only.
- net462/net48 (OWIN) stay on Windows + MSBuild — out of mise's scope.
- Existing `build.yml` keeps using `actions/setup-dotnet`; it transparently honours `global.json`.

## aube replacing pnpm (React sample only)

- aube reads/writes the existing `pnpm-lock.yaml` **in place** — verified locally that `aube install` produced **zero** lockfile diff.
- `package.json`: removed the `packageManager` (Corepack) field.
- `.csproj` MSBuild targets and `SpaProxyLaunchCommand`: `pnpm` → `aube`.
- CI (`build-react-sample-client.yml`, `e2e-tests.yml`): `setup-node` + corepack + pnpm cache → **`jdx/mise-action`** with `install_args: aube node`, then `aube ci` (frozen lockfile). aube/node versions come solely from `mise.toml` (single source of truth) — no version duplicated in the workflows.
- The aube global store (`aube store path`) is cached via `actions/cache`, keyed on `pnpm-lock.yaml` (mise-action's own cache only covers the mise-installed tool binaries, not the package store).
- Devcontainer provisions aube via `mise install aube` (version pinned in `mise.toml`; checksum-verified prebuilt binary — no npm lifecycle scripts).

## Single source of truth for the aube version

`mise.toml` is the only place the aube version is declared — local dev, the devcontainer (`mise install aube`), and CI (`jdx/mise-action`) all read from it.

## Verification

- `dotnet --version` → `10.0.301` (satisfies `global.json`).
- `aube ci` (frozen) → `aube lint` ✅ · `aube build` ✅ (vite production build).
- `mise.toml` resolves: dotnet `10`→10.0.301, `8`→8.0.422 (aspnetcore runtime), node `lts`→24.18.0, aube 1.25.1.

## Security notes (automated review)

- The devcontainer and CI install aube via **mise**, which fetches a checksum-verified prebuilt binary, rather than `npm install --ignore-scripts=false` — so no untrusted npm install scripts run.
- `jdx/mise-action@v4` is pinned by major tag, matching the repo's existing convention for **all** GitHub Actions and tracked by the existing `github-actions` Dependabot updater. SHA-pinning is intentionally left as a separate repo-wide hardening decision rather than forking the convention for one action.

> [!NOTE]
> This PR's file changes trigger `build-react-sample-client` and `e2e-tests` (which exercise the new aube CI path) but not `build.yml`, so the dotnet CI is unchanged by design.
