### PR TITLE
build(deps): add nuget groups and cooldown to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,36 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3
+    groups:
+      aspnetcore:
+        patterns:
+          - Microsoft.AspNetCore.*
+      entityframeworkcore:
+        patterns:
+          - Microsoft.EntityFrameworkCore.*
+      extensions:
+        patterns:
+          - Microsoft.Extensions.*
+      owin:
+        patterns:
+          - Microsoft.Owin.*
+      saml2:
+        patterns:
+          - Sustainsys.Saml2.*
+      playwright:
+        patterns:
+          - Microsoft.Playwright*
+      test-sdk:
+        patterns:
+          - Microsoft.NET.Test.Sdk
+          - Microsoft.TestPlatform.ObjectModel
+      xunit:
+        patterns:
+          - xunit.*
+      system:
+        patterns:
+          - System.Security.Cryptography.Xml
+          - System.Text.Encodings.Web
+          - System.Text.Json


### PR DESCRIPTION
## Summary
- Add `cooldown: default-days: 3` to the nuget ecosystem, matching the existing npm config, to avoid immediately picking up freshly-published (and possibly yanked) package versions.
- Add `groups` for nuget packages that share a version variable in `Directory.Packages.props` (`Microsoft.AspNetCore.*`, `Microsoft.EntityFrameworkCore.*`, `Microsoft.Extensions.*`, `Microsoft.Owin.*`, `Sustainsys.Saml2.*`, `Microsoft.Playwright*`, `xunit.*`, test-sdk, system packages), so one shared-variable bump opens a single PR instead of several near-duplicate ones — e.g. #848, #849, #850, #851, #852 all bumped different `Microsoft.AspNetCore.*` packages to `10.0.2` on the same day.

Not addressed here: recurring Dependabot PRs proposing major-version bumps for packages intentionally floor-pinned to `8.0.x` for `netstandard2.0`/`net462` compatibility (e.g. #822, #486, #133, #53). Dependabot's `ignore` matches by package name + semver range, not by target framework, so an `ignore` rule would also block the legitimate modern-TFM upgrade path for the same package name. No clean config fix exists for this; closing those PRs manually remains the right call.

## Test plan
- [x] Validated YAML syntax (`ruby -ryaml -e "YAML.load_file(...)"`)
- [ ] Confirm Dependabot picks up the new config on its next scheduled run