### PR TITLE
Upgrade Keycloak to 26.6.4

### DIFF
--- a/.devcontainer/keycloak/Dockerfile
+++ b/.devcontainer/keycloak/Dockerfile
@@ -1,7 +1,7 @@
-# https://github.com/keycloak/keycloak/releases/tag/26.6.3
-ARG KEYCLOAK_VERSION=26.6.3
-# https://github.com/jacekkow/keycloak-protocol-cas/releases/tag/26.6.3
-ARG KEYCLOAK_CAS_VERSION=26.6.3
+# https://github.com/keycloak/keycloak/releases/tag/26.6.4
+ARG KEYCLOAK_VERSION=26.6.4
+# https://github.com/jacekkow/keycloak-protocol-cas/releases/tag/26.6.4
+ARG KEYCLOAK_CAS_VERSION=26.6.4
 FROM quay.io/keycloak/keycloak:${KEYCLOAK_VERSION}
 ARG KEYCLOAK_VERSION
 ARG KEYCLOAK_CAS_VERSION


### PR DESCRIPTION
# Pull Request

## Description

Upgrades the Keycloak Docker image and CAS protocol extension to version 26.6.4 in the dev container configuration.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (requires major version bump)
- [ ] Refactoring / maintenance
- [ ] Documentation update
- [x] Dependency update
- [ ] CI/CD change

## Changes

- Updated `KEYCLOAK_VERSION` from 26.6.3 to 26.6.4
- Updated `KEYCLOAK_CAS_VERSION` from 26.6.3 to 26.6.4
- Updated documentation links to point to the new release tags

## Testing

No testing needed — this is a patch version bump for the dev container. E2E tests will use the updated Keycloak version when the dev container is rebuilt.

## Checklist

- [x] I have applied an appropriate **PR label** (required for release notes)
- [x] `dotnet build -c Release` passes with no warnings
- [x] `dotnet test --filter "FullyQualifiedName!~E2E"` passes
- [ ] Added or updated tests for behavior changes
- [ ] Public API changes include XML documentation comments

https://claude.ai/code/session_019kLzwCcZPUGJufQg2sZxYW