### PR TITLE
fix(deps): patch security vulnerabilities in React sample client

### DIFF
--- a/samples/AspNetCoreReactSample/ClientApp/pnpm-lock.yaml
+++ b/samples/AspNetCoreReactSample/ClientApp/pnpm-lock.yaml
@@ -5,13 +5,17 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  react-router: ^6.30.3
   '@remix-run/router': ^1.23.2
+  brace-expansion: ^5.0.8
+  react-router: ^7.18.1
 
 importers:
 
   .:
     dependencies:
+      '@popperjs/core':
+        specifier: ^2.11.8
+        version: 2.11.8
       bootstrap:
         specifier: 5.3.8
         version: 5.3.8(@popperjs/core@2.11.8)
@@ -23,7 +27,10 @@ importers:
         version: 19.2.8(react@19.2.8)
       react-router-bootstrap:
         specifier: 0.26.3
-        version: 0.26.3(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 0.26.3(react@19.2.8)(react-router-dom@7.18.1(react@19.2.8)(react-dom@19.2.8(react@19.2.8)))
+      react-router-dom:
+        specifier: '>=6.0.0'
+        version: 7.18.1(react@19.2.8)(react-dom@19.2.8(react@19.2.8))
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
@@ -149,10 +156,6 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
-
-  '@remix-run/router@1.23.3':
-    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
-    engines: {node: '>=14.0.0'}
 
   '@rolldown/binding-android-arm64@1.1.5':
     resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
@@ -363,9 +366,13 @@ packages:
     peerDependencies:
       '@popperjs/core': ^2.11.8
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -695,18 +702,22 @@ packages:
       react: '>=16.13.1'
       react-router-dom: '>=6.0.0'
 
-  react-router-dom@7.16.0:
-    resolution: {integrity: sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==}
+  react-router-dom@7.18.1:
+    resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@6.30.4:
-    resolution: {integrity: sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==}
-    engines: {node: '>=14.0.0'}
+  react-router@7.18.1:
+    resolution: {integrity: sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      react: '>=16.8'
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
@@ -733,6 +744,9 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -897,7 +911,7 @@ snapshots:
       '@types/json-schema': 7.0.15
 
   '@eslint/js@10.0.1(eslint@10.7.0)':
-    optionalDependencies:
+    dependencies:
       eslint: 10.7.0
 
   '@eslint/object-schema@3.0.5': {}
@@ -933,8 +947,6 @@ snapshots:
   '@oxc-project/types@0.139.0': {}
 
   '@popperjs/core@2.11.8': {}
-
-  '@remix-run/router@1.23.3': {}
 
   '@rolldown/binding-android-arm64@1.1.5':
     optional: true
@@ -1125,9 +1137,11 @@ snapshots:
     dependencies:
       '@popperjs/core': 2.11.8
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
+
+  cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1342,7 +1356,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minipass@7.1.3: {}
 
@@ -1411,22 +1425,24 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-router-bootstrap@0.26.3(react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
+  react-router-bootstrap@0.26.3(react@19.2.8)(react-router-dom@7.18.1(react@19.2.8)(react-dom@19.2.8(react@19.2.8))):
     dependencies:
       prop-types: 15.8.1
       react: 19.2.8
-      react-router-dom: 7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router-dom: 7.18.1(react@19.2.8)(react-dom@19.2.8(react@19.2.8))
 
-  react-router-dom@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router-dom@7.18.1(react@19.2.8)(react-dom@19.2.8(react@19.2.8)):
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      react-router: 6.30.4(react@19.2.8)
+      react-router: 7.18.1(react@19.2.8)(react-dom@19.2.8(react@19.2.8))
 
-  react-router@6.30.4(react@19.2.8):
+  react-router@7.18.1(react@19.2.8)(react-dom@19.2.8(react@19.2.8)):
     dependencies:
-      '@remix-run/router': 1.23.3
+      cookie: 1.1.1
       react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      set-cookie-parser: 2.7.2
 
   react@19.2.8: {}
 
@@ -1461,6 +1477,8 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@7.8.5: {}
+
+  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -1511,13 +1529,13 @@ snapshots:
 
   vite@8.1.5(@types/node@26.1.1):
     dependencies:
+      '@types/node': 26.1.1
       lightningcss: 1.32.0
       picomatch: 4.0.5
       postcss: 8.5.20
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.1.1
       fsevents: 2.3.3
 
   web-vitals@6.0.0: {}

--- a/samples/AspNetCoreReactSample/ClientApp/pnpm-workspace.yaml
+++ b/samples/AspNetCoreReactSample/ClientApp/pnpm-workspace.yaml
@@ -7,7 +7,8 @@ onlyBuiltDependencies:
   - esbuild
 
 overrides:
-  react-router: "^6.30.3"
+  react-router: "^7.18.1"
+  brace-expansion: "^5.0.8"
   "@remix-run/router": "^1.23.2"
 
 peerDependencyRules:


### PR DESCRIPTION
Fixes Dependabot Security Alerts #77, #78, #79 in `/samples/AspNetCoreReactSample/ClientApp`:

- `brace-expansion`: updated override to `^5.0.8` (fixes GHSA-mh99-v99m-4gvg / CVE-2026-14257)
- `react-router`: updated override to `^7.18.1` (fixes GHSA-wrjc-x8rr-h8h6 / CVE-2026-53669 & GHSA-337j-9hxr-rhxg / CVE-2026-53666)