### PR TITLE
ci(dependabot): group frontend dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,16 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Workflows intentionally use floating major tags. Ignore the expanded
+    # version tags Dependabot resolves within those majors, while still
+    # surfacing a future major action upgrade.
+    ignore:
+      - dependency-name: reviewdog/action-hadolint
+        versions:
+          - 1.x
+      - dependency-name: jdx/mise-action
+        versions:
+          - 4.x
   - package-ecosystem: npm
     directory: /samples/AspNetCoreReactSample/ClientApp
     schedule:
@@ -12,13 +22,13 @@ updates:
     cooldown:
       default-days: 3
     groups:
-      react:
+      typescript:
         patterns:
-          - react
-          - react-dom
-          - '@types/react'
-          - '@types/react-dom'
-          - '@vitejs/plugin-react'
+          - typescript
+          - typescript-eslint
+      frontend:
+        patterns:
+          - '*'
   - package-ecosystem: nuget
     directory: /
     schedule:


### PR DESCRIPTION
## Summary

- suppress expanded versions for GitHub Actions pinned to floating major tags
- group TypeScript and typescript-eslint updates before other frontend dependencies
- group the remaining React sample frontend updates into one Dependabot PR

## Why

Avoids recurring PRs for action versions already covered by `@v1` and `@v4`, while keeping TypeScript toolchain releases aligned.

## Validation

- YAML parsing
- `aubr lint`
- `aubr build`