### PR TITLE
build(deps): update react-router to 8.3.0 to fix security alert #80

### DIFF
--- a/samples/AspNetCoreReactSample/ClientApp/pnpm-lock.yaml
+++ b/samples/AspNetCoreReactSample/ClientApp/pnpm-lock.yaml
@@ -7,12 +7,15 @@ settings:
 overrides:
   '@remix-run/router': ^1.23.2
   brace-expansion: ^5.0.8
-  react-router: ^7.18.1
+  react-router: ^8.3.0
 
 importers:
 
   .:
     dependencies:
+      '@popperjs/core':
+        specifier: ^2.11.8
+        version: 2.11.8
       bootstrap:
         specifier: 5.3.8
         version: 5.3.8(@popperjs/core@2.11.8)
@@ -24,7 +27,10 @@ importers:
         version: 19.2.8(react@19.2.8)
       react-router-bootstrap:
         specifier: 0.26.3
-        version: 0.26.3(react-router-dom@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 0.26.3(react@19.2.8)(react-router-dom@7.18.1(react@19.2.8)(react-dom@19.2.8(react@19.2.8)))
+      react-router-dom:
+        specifier: '>=6.0.0'
+        version: 7.18.1(react@19.2.8)(react-dom@19.2.8(react@19.2.8))
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
@@ -364,9 +370,8 @@ packages:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
-  cookie@1.1.1:
-    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
-    engines: {node: '>=18'}
+  cookie-es@3.1.1:
+    resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -707,12 +712,12 @@ packages:
       react: '>=18'
       react-dom: '>=18'
 
-  react-router@7.18.2:
-    resolution: {integrity: sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==}
-    engines: {node: '>=20.0.0'}
+  react-router@8.3.0:
+    resolution: {integrity: sha512-qyPMvW83jGIct3yiieisxdk9M745anqhpIMKN5m1t6yBMfgVPpt77aHOqs5fUlEJRMCGffg9BaQLH9oPVOL7xQ==}
+    engines: {node: '>=22.22.0'}
     peerDependencies:
-      react: '>=18'
-      react-dom: '>=18'
+      react: '>=19.2.7'
+      react-dom: '>=19.2.7'
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -742,9 +747,6 @@ packages:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
-
-  set-cookie-parser@2.7.2:
-    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -904,7 +906,7 @@ snapshots:
       '@types/json-schema': 7.0.15
 
   '@eslint/js@10.0.1(eslint@10.8.0)':
-    optionalDependencies:
+    dependencies:
       eslint: 10.8.0
 
   '@eslint/object-schema@3.0.5': {}
@@ -1134,7 +1136,7 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
-  cookie@1.1.1: {}
+  cookie-es@3.1.1: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1418,24 +1420,22 @@ snapshots:
 
   react-is@16.13.1: {}
 
-  react-router-bootstrap@0.26.3(react-router-dom@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8):
+  react-router-bootstrap@0.26.3(react@19.2.8)(react-router-dom@7.18.1(react@19.2.8)(react-dom@19.2.8(react@19.2.8))):
     dependencies:
       prop-types: 15.8.1
       react: 19.2.8
-      react-router-dom: 7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router-dom: 7.18.1(react@19.2.8)(react-dom@19.2.8(react@19.2.8))
 
-  react-router-dom@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router-dom@7.18.1(react@19.2.8)(react-dom@19.2.8(react@19.2.8)):
     dependencies:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      react-router: 7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      react-router: 8.3.0(react@19.2.8)(react-dom@19.2.8(react@19.2.8))
 
-  react-router@7.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  react-router@8.3.0(react@19.2.8)(react-dom@19.2.8(react@19.2.8)):
     dependencies:
-      cookie: 1.1.1
+      cookie-es: 3.1.1
       react: 19.2.8
-      set-cookie-parser: 2.7.2
-    optionalDependencies:
       react-dom: 19.2.8(react@19.2.8)
 
   react@19.2.8: {}
@@ -1471,8 +1471,6 @@ snapshots:
   scheduler@0.27.0: {}
 
   semver@7.8.5: {}
-
-  set-cookie-parser@2.7.2: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -1523,13 +1521,13 @@ snapshots:
 
   vite@8.1.5(@types/node@26.1.2):
     dependencies:
+      '@types/node': 26.1.2
       lightningcss: 1.32.0
       picomatch: 4.0.5
       postcss: 8.5.20
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.1.2
       fsevents: 2.3.3
 
   web-vitals@6.0.1: {}

--- a/samples/AspNetCoreReactSample/ClientApp/pnpm-workspace.yaml
+++ b/samples/AspNetCoreReactSample/ClientApp/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ onlyBuiltDependencies:
   - esbuild
 
 overrides:
-  react-router: "^7.18.1"
+  react-router: "^8.3.0"
   brace-expansion: "^5.0.8"
   "@remix-run/router": "^1.23.2"
 


### PR DESCRIPTION
Bumps `react-router` override to `^8.3.0` to resolve Dependabot security alert #80 (GHSA-qwww-vcr4-c8h2).

Release notes: https://github.com/remix-run/react-router/releases/tag/react-router@8.3.0