### PR TITLE
chore(release): prepare 5.8.0-rc.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,7 +16,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
-    <Version>5.7.0</Version>
+    <Version>5.8.0-rc.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release' ">


### PR DESCRIPTION
## Summary

- set the package version to `5.8.0-rc.0` for the Trusted Publishing validation release

## Verification

- `dotnet test --filter "FullyQualifiedName!~E2E"`
- `dotnet pack --no-restore -o <temporary directory>`

The package artifacts use the intended `5.8.0-rc.0` version.