### PR TITLE
chore(release): prepare 5.8.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,7 @@
     <PackageTags>cas;sso;authentication;aspnetcore;owin;middleware</PackageTags>
     <PackageProjectUrl>https://github.com/akunzai/GSS.Authentication.CAS</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>See https://github.com/akunzai/GSS.Authentication.CAS/releases</PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
@@ -16,7 +17,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
-    <Version>5.8.0-rc.0</Version>
+    <Version>5.8.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release' ">
@@ -28,5 +29,9 @@
   <PropertyGroup Condition="'$(CI)' == 'True' ">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)../README.md" Pack="true" PackagePath="\" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

- release the final `5.8.0` packages
- include the repository README in every NuGet package

## Verification

- `dotnet test --filter "FullyQualifiedName!~E2E"`
- `dotnet pack --no-restore -o <temporary directory>`
- inspected all three `.nupkg` files and confirmed each contains `README.md`

Closes #997