### PR TITLE
fix(deps): bump System.Security.Cryptography.Xml to 8.0.4 to fix CVE-2026-50527

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
-    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.3" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="8.0.4" />
     <PackageVersion Include="System.Text.Encodings.Web" Version="8.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>


### PR DESCRIPTION
### Description

This PR updates `System.Security.Cryptography.Xml` from `8.0.3` to `8.0.4` in `Directory.Packages.props` for `netstandard2.0` and `net462` target frameworks to address security vulnerability **CVE-2026-50527** (Stack-based buffer overflow causing Denial of Service).

### Changes
- Updated `System.Security.Cryptography.Xml` package version from `8.0.3` to `8.0.4` in [`Directory.Packages.props`](file:///Users/akunzai/code/GSS.Authentication.CAS/Directory.Packages.props).

### Verification
- Executed `dotnet test --filter "FullyQualifiedName!~E2E"` across all supported targets with 0 failures (246 passed).