### PR TITLE
fix: honor CAS sign-out event (release 5.8.1)

### DIFF
--- a/owin/GSS.Authentication.CAS.Owin.Tests/CasAuthenticationMiddlewareTests.cs
+++ b/owin/GSS.Authentication.CAS.Owin.Tests/CasAuthenticationMiddlewareTests.cs
@@ -318,6 +318,179 @@ namespace GSS.Authentication.CAS.Owin.Tests
             Assert.Equal("/Account/ExternalLoginFailure", signInResponse.Headers.Location.OriginalString);
         }
 
+        [Fact]
+        public async Task SignInChallenge_WithoutCorrelationCookie_ShouldThrows()
+        {
+            // Arrange
+            using var server = CreateServer(options => options.CasServerUrlBase = CasServerUrlBase);
+            using var challengeResponse = await server.HttpClient.GetAsync(CookieAuthenticationDefaults.LoginPath.Value, TestContext.Current.CancellationToken);
+            var query = QueryHelpers.ParseQuery(challengeResponse.Headers.Location.Query);
+            var callbackUrl = query[Constants.Parameters.Service].ToString();
+            var exception = await Record.ExceptionAsync(async () =>
+            {
+                // Act
+                await server.HttpClient.GetAsync(callbackUrl, TestContext.Current.CancellationToken);
+            });
+
+            // Assert
+            Assert.NotNull(exception);
+            Assert.Equal("An error was encountered while handling the remote login.", exception.Message);
+            Assert.Equal("Invalid return state, unable to redirect.", exception.InnerException!.Message);
+        }
+
+        [Fact]
+        public async Task SignInChallenge_WithSaveTokens_ShouldStoreServiceTicket()
+        {
+            // Arrange
+            var ticketValidator = Substitute.For<IServiceTicketValidator>();
+            var ticket = Guid.NewGuid().ToString();
+            var principal = new CasPrincipal(new Assertion(Guid.NewGuid().ToString()), CasDefaults.AuthenticationType);
+            ticketValidator
+                .ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<ICasPrincipal?>(principal));
+            string? savedTicket = null;
+            using var server = CreateServer(options =>
+            {
+                options.ServiceTicketValidator = ticketValidator;
+                options.CasServerUrlBase = CasServerUrlBase;
+                options.SaveTokens = true;
+                options.Provider = new CasAuthenticationProvider
+                {
+                    OnCreatingTicket = context =>
+                    {
+                        savedTicket = context.Properties.GetServiceTicket();
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+            using var challengeResponse = await server.HttpClient.GetAsync(CookieAuthenticationDefaults.LoginPath.Value, TestContext.Current.CancellationToken);
+            var query = QueryHelpers.ParseQuery(challengeResponse.Headers.Location.Query);
+            var validateUrl =
+                QueryHelpers.AddQueryString(query[Constants.Parameters.Service], Constants.Parameters.Ticket, ticket);
+
+            // Act
+            using var signInRequest = challengeResponse.GetRequestWithCookies(validateUrl);
+            using var signInResponse = await server.HttpClient.SendAsync(signInRequest, TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Found, signInResponse.StatusCode);
+            Assert.Equal(ticket, savedTicket);
+        }
+
+        [Fact]
+        public async Task SignInChallenge_WithoutRedirectUri_ShouldReturnToCurrentPath()
+        {
+            // Arrange
+            var ticketValidator = Substitute.For<IServiceTicketValidator>();
+            var ticket = Guid.NewGuid().ToString();
+            var principal = new CasPrincipal(new Assertion(Guid.NewGuid().ToString()), CasDefaults.AuthenticationType);
+            ticketValidator
+                .ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<ICasPrincipal?>(principal));
+            using var server = CreateServer(options =>
+            {
+                options.ServiceTicketValidator = ticketValidator;
+                options.CasServerUrlBase = CasServerUrlBase;
+            });
+            using var challengeResponse = await server.HttpClient.GetAsync("/challenge", TestContext.Current.CancellationToken);
+            var query = QueryHelpers.ParseQuery(challengeResponse.Headers.Location.Query);
+            var validateUrl =
+                QueryHelpers.AddQueryString(query[Constants.Parameters.Service], Constants.Parameters.Ticket, ticket);
+
+            // Act
+            using var signInRequest = challengeResponse.GetRequestWithCookies(validateUrl);
+            using var signInResponse = await server.HttpClient.SendAsync(signInRequest, TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Found, signInResponse.StatusCode);
+            Assert.Equal("http://localhost/challenge", signInResponse.Headers.Location.OriginalString);
+        }
+
+        [Fact]
+        public async Task SingleSignOut_ShouldRedirectToCasServer()
+        {
+            // Arrange
+            using var server = CreateServer(options => options.CasServerUrlBase = CasServerUrlBase);
+
+            // Act
+            using var response = await server.HttpClient.GetAsync("/cas-signout", TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+            var callbackUrl = QueryHelpers.AddQueryString("http://localhost/signout-callback-cas", "state", string.Empty);
+            var expectedUrlPrefix =
+                QueryHelpers.AddQueryString(CasServerUrlBase + Constants.Paths.Logout, "service", callbackUrl);
+            Assert.StartsWith(expectedUrlPrefix, response.Headers.Location.AbsoluteUri);
+        }
+
+        [Fact]
+        public async Task SingleSignOutCallback_WithState_ShouldRedirectToSignedOutRedirectUri()
+        {
+            // Arrange
+            const string signedOutRedirectUri = "https://app.example.org/logged-out";
+            using var server = CreateServer(options =>
+            {
+                options.CasServerUrlBase = CasServerUrlBase;
+                options.SignedOutRedirectUri = signedOutRedirectUri;
+            });
+            using var signOutResponse = await server.HttpClient.GetAsync("/cas-signout", TestContext.Current.CancellationToken);
+            var logoutQuery = QueryHelpers.ParseQuery(signOutResponse.Headers.Location.Query);
+            var callbackUrl = logoutQuery[Constants.Parameters.Service].ToString();
+
+            // Act
+            using var callbackResponse = await server.HttpClient.GetAsync(callbackUrl, TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Found, callbackResponse.StatusCode);
+            Assert.Equal(signedOutRedirectUri, callbackResponse.Headers.Location.AbsoluteUri);
+        }
+
+        [Fact]
+        public async Task SingleSignOutCallback_WithoutState_ShouldRedirectToSignedOutRedirectUri()
+        {
+            // Arrange
+            const string signedOutRedirectUri = "/logged-out";
+            using var server = CreateServer(options =>
+            {
+                options.CasServerUrlBase = CasServerUrlBase;
+                options.SignedOutRedirectUri = signedOutRedirectUri;
+            });
+
+            // Act
+            using var response = await server.HttpClient.GetAsync("/signout-callback-cas", TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+            Assert.Equal(signedOutRedirectUri, response.Headers.Location.OriginalString);
+        }
+
+        [Fact]
+        public async Task SingleSignOut_WhenRedirectHandled_ShouldSkipCasLogout()
+        {
+            // Arrange
+            const string customLogoutPath = "/custom-signout";
+            using var server = CreateServer(options =>
+            {
+                options.CasServerUrlBase = CasServerUrlBase;
+                options.Provider = new CasAuthenticationProvider
+                {
+                    OnRedirectToIdentityProviderForSignOut = context =>
+                    {
+                        context.Response.Redirect(customLogoutPath);
+                        context.HandleResponse();
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+
+            // Act
+            using var response = await server.HttpClient.GetAsync("/cas-signout", TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+            Assert.Equal(customLogoutPath, response.Headers.Location.OriginalString);
+        }
+
         private static TestServer CreateServer(Action<CasAuthenticationOptions> configureOptions)
         {
             var options = new CasAuthenticationOptions();
@@ -340,6 +513,18 @@ namespace GSS.Authentication.CAS.Owin.Tests
                     {
                         context.Authentication.Challenge(new AuthenticationProperties { RedirectUri = "/" },
                             CasDefaults.AuthenticationType);
+                        return;
+                    }
+
+                    if (request.Path.Value == "/challenge")
+                    {
+                        context.Authentication.Challenge(CasDefaults.AuthenticationType);
+                        return;
+                    }
+
+                    if (request.Path.Value == "/cas-signout")
+                    {
+                        context.Authentication.SignOut(CasDefaults.AuthenticationType);
                         return;
                     }
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
-    <Version>5.8.0</Version>
+    <Version>5.8.1</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release' ">

--- a/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs
@@ -94,7 +94,7 @@ public class CasAuthenticationHandler : RemoteAuthenticationHandler<CasAuthentic
                     Options.StateDataFormat.Protect(properties))));
         var redirectContext = new CasRedirectContext(Context, Scheme, Options, properties, redirectUri);
 
-        await Events.RedirectToAuthorizationEndpoint(redirectContext).ConfigureAwait(false);
+        await Events.RedirectToIdentityProviderForSignOut(redirectContext).ConfigureAwait(false);
         if (redirectContext.Handled)
         {
             return;

--- a/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
@@ -43,7 +43,7 @@ namespace GSS.Authentication.CAS.Owin
         {
             var query = Request.Query;
             var state = query[State];
-            var properties = Options.StateDataFormat.Unprotect(state);
+            var properties = string.IsNullOrEmpty(state) ? null : Options.StateDataFormat.Unprotect(state);
             Response.Redirect(!string.IsNullOrEmpty(properties?.RedirectUri)
                 ? properties!.RedirectUri
                 : Options.SignedOutRedirectUri);

--- a/test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationMiddlewareTests.cs
+++ b/test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationMiddlewareTests.cs
@@ -431,6 +431,186 @@ public class CasAuthenticationMiddlewareTests
             .Received(1).ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task SignInChallenge_WithoutCorrelationCookie_ShouldThrows()
+    {
+        // Arrange
+        using var host = CreateHost(options => options.CasServerUrlBase = CasServerUrlBase);
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+        using var challengeResponse =
+            await client.GetAsync(CookieAuthenticationDefaults.LoginPath, TestContext.Current.CancellationToken);
+        var query = QueryHelpers.ParseQuery(challengeResponse.Headers.Location?.Query);
+        var callbackUrl = query[Constants.Parameters.Service].ToString();
+
+        var exception = await Record.ExceptionAsync(async () =>
+        {
+            // Act
+            await client.GetAsync(callbackUrl, TestContext.Current.CancellationToken);
+        });
+
+        // Assert
+        Assert.NotNull(exception);
+        Assert.Equal("An error was encountered while handling the remote login.", exception.Message);
+        Assert.Equal("Correlation failed", exception.InnerException!.Message);
+    }
+
+    [Fact]
+    public async Task SignInChallenge_WithSaveTokens_ShouldStoreServiceTicket()
+    {
+        // Arrange
+        var ticketValidator = Substitute.For<IServiceTicketValidator>();
+        var ticket = Guid.NewGuid().ToString();
+        var principal = new CasPrincipal(new Assertion(Guid.NewGuid().ToString()), CasDefaults.AuthenticationType);
+        ticketValidator
+            .ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ICasPrincipal?>(principal));
+        string? savedTicket = null;
+        using var host = CreateHost(options =>
+        {
+            options.ServiceTicketValidator = ticketValidator;
+            options.CasServerUrlBase = CasServerUrlBase;
+            options.SaveTokens = true;
+            options.Events = new CasEvents
+            {
+                OnCreatingTicket = context =>
+                {
+                    savedTicket = context.Properties.GetServiceTicket();
+                    return Task.CompletedTask;
+                }
+            };
+        });
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+        using var challengeResponse =
+            await client.GetAsync(CookieAuthenticationDefaults.LoginPath, TestContext.Current.CancellationToken);
+        var query = QueryHelpers.ParseQuery(challengeResponse.Headers.Location?.Query);
+        var validateUrl =
+            QueryHelpers.AddQueryString(query[Constants.Parameters.Service]!, Constants.Parameters.Ticket, ticket);
+
+        // Act
+        using var signInRequest = challengeResponse.GetRequestWithCookies(validateUrl);
+        using var signInResponse = await client.SendAsync(signInRequest, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Found, signInResponse.StatusCode);
+        Assert.Equal(ticket, savedTicket);
+    }
+
+    [Fact]
+    public async Task SignInChallenge_WithoutRedirectUri_ShouldReturnToCurrentPath()
+    {
+        // Arrange
+        var ticketValidator = Substitute.For<IServiceTicketValidator>();
+        var ticket = Guid.NewGuid().ToString();
+        var principal = new CasPrincipal(new Assertion(Guid.NewGuid().ToString()), CasDefaults.AuthenticationType);
+        ticketValidator
+            .ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ICasPrincipal?>(principal));
+        using var host = CreateHost(options =>
+        {
+            options.ServiceTicketValidator = ticketValidator;
+            options.CasServerUrlBase = CasServerUrlBase;
+        });
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+        using var challengeResponse =
+            await client.GetAsync("/challenge", TestContext.Current.CancellationToken);
+        var query = QueryHelpers.ParseQuery(challengeResponse.Headers.Location?.Query);
+        var validateUrl =
+            QueryHelpers.AddQueryString(query[Constants.Parameters.Service]!, Constants.Parameters.Ticket, ticket);
+
+        // Act
+        using var signInRequest = challengeResponse.GetRequestWithCookies(validateUrl);
+        using var signInResponse = await client.SendAsync(signInRequest, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Found, signInResponse.StatusCode);
+        Assert.Equal("/challenge", signInResponse.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task SingleSignOutCallback_WithState_ShouldRedirectToSignedOutRedirectUri()
+    {
+        // Arrange
+        const string signedOutRedirectUri = "https://app.example.org/logged-out";
+        using var host = CreateHost(options =>
+        {
+            options.CasServerUrlBase = CasServerUrlBase;
+            options.SignedOutRedirectUri = signedOutRedirectUri;
+        });
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+        using var signOutResponse =
+            await client.GetAsync("/cas-signout", TestContext.Current.CancellationToken);
+        var logoutQuery = QueryHelpers.ParseQuery(signOutResponse.Headers.Location?.Query);
+        var callbackUrl = logoutQuery[Constants.Parameters.Service].ToString();
+
+        // Act
+        using var callbackResponse = await client.GetAsync(callbackUrl, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Found, callbackResponse.StatusCode);
+        Assert.Equal(signedOutRedirectUri, callbackResponse.Headers.Location?.AbsoluteUri);
+    }
+
+    [Fact]
+    public async Task SingleSignOutCallback_WithoutState_ShouldRedirectToSignedOutRedirectUri()
+    {
+        // Arrange
+        const string signedOutRedirectUri = "/logged-out";
+        using var host = CreateHost(options =>
+        {
+            options.CasServerUrlBase = CasServerUrlBase;
+            options.SignedOutRedirectUri = signedOutRedirectUri;
+        });
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+
+        // Act
+        using var response =
+            await client.GetAsync("/signout-callback-cas", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Equal(signedOutRedirectUri, response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task SingleSignOut_WhenRedirectHandled_ShouldSkipCasLogout()
+    {
+        // Arrange
+        const string customLogoutPath = "/custom-signout";
+        using var host = CreateHost(options =>
+        {
+            options.CasServerUrlBase = CasServerUrlBase;
+            options.Events = new CasEvents
+            {
+                OnRedirectToIdentityProviderForSignOut = context =>
+                {
+                    context.Response.Redirect(customLogoutPath);
+                    context.HandleResponse();
+                    return Task.CompletedTask;
+                }
+            };
+        });
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/cas-signout", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+        Assert.Equal(customLogoutPath, response.Headers.Location?.OriginalString);
+    }
+
     private static IHost CreateHost(Action<CasAuthenticationOptions> configureOptions,
         Action<CookieAuthenticationOptions>? configureCookie = null)
     {
@@ -461,6 +641,20 @@ public class CasAuthenticationMiddlewareTests
                             {
                                 await context.ChallengeAsync(CasDefaults.AuthenticationType,
                                     new AuthenticationProperties { RedirectUri = "/" });
+                            });
+                        });
+                        app.Map("/challenge", challengeApp =>
+                        {
+                            challengeApp.Run(async context =>
+                            {
+                                await context.ChallengeAsync(CasDefaults.AuthenticationType);
+                            });
+                        });
+                        app.Map("/cas-signout", casSignOutApp =>
+                        {
+                            casSignOutApp.Run(async context =>
+                            {
+                                await context.SignOutAsync(CasDefaults.AuthenticationType);
                             });
                         });
                         app.Map(CookieAuthenticationDefaults.LogoutPath, signOutApp =>


### PR DESCRIPTION
# Pull Request

## Description

Adds the high-value handler tests identified from the Codecov report, and prepares **5.8.1**.

**Bug fix:** `CasAuthenticationHandler.SignOutAsync` (AspNetCore) called `RedirectToAuthorizationEndpoint` instead of `RedirectToIdentityProviderForSignOut`, so `OnRedirectToIdentityProviderForSignOut` / `HandleResponse()` never ran. OWIN already called the correct event.

**Also:** OWIN sign-out callback no longer calls `Unprotect` when `state` is missing.

Default logout (no custom events) is unchanged. This is a patch because only subscribers of the sign-out event, or people who accidentally customized logout via the login redirect event, see a behavior change.

New tests (AspNetCore + OWIN): CSRF correlation failure, `SaveTokens`, challenge without `RedirectUri`, sign-out callback, handled sign-out, OWIN SLO redirect.

After merge to `main`, push tag `v5.8.1` to publish GitHub release + NuGet.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change (requires major version bump)
- [ ] Refactoring / maintenance
- [ ] Documentation update
- [ ] Dependency update
- [ ] CI/CD change

## Checklist

- [x] I have applied an appropriate **PR label** (required for release notes)
- [x] `dotnet build -c Release` passes with no warnings
- [x] `dotnet test --filter "FullyQualifiedName!~E2E"` passes
- [x] Added or updated tests for behavior changes
- [ ] Public API changes include XML documentation comments