### PR TITLE
ci: exclusive release-drafter categories

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -14,6 +14,10 @@ refactor:
   - head-branch:
     - '^refactor/.+'
 
+chore:
+  - head-branch:
+    - '^chore/.+'
+
 dependencies:
   - head-branch:
     - '^dependabot/.+'
@@ -24,28 +28,27 @@ dependencies:
       - '.config/dotnet-tools.json'
       - '**/Directory.Packages.props'
 
+# Workflows and ci/* branches only — not every file under .github/
 github_actions:
   - head-branch:
     - '^ci/.+'
   - changed-files:
     - any-glob-to-any-file:
       - '.github/workflows/**/*'
-      - '.github/*.yml'
 
+# Sample apps only — owin/ is the OWIN library, not a sample
 samples:
   - all:
     - changed-files:
       - any-glob-to-any-file:
         - 'samples/**/*'
-        - 'owin/**/*'
     - head-branch:
       - '^(?!dependabot/).+'
 
+# Dedicated docs tree / docs? branches — not every *.md touch
 documentation:
   - head-branch:
     - '^docs?/.+'
   - changed-files:
     - any-glob-to-any-file:
       - 'docs/**/*'
-      - '*.md'
-      - 'LICENSE'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,56 +3,70 @@ tag-template: 'v$RESOLVED_VERSION'
 exclude-contributors:
   - dependabot
   - renovate
+# Changelog categories are exclusive and ordered by precedence.
+# Type labels (breaking → chore) win over area labels (samples, docs).
 categories:
   - title: '⚡️ Breaking Changes'
+    exclusive: true
     when:
       label: breaking
   - title: '🚀 Features'
+    exclusive: true
     when:
       labels:
         - feature
         - enhancement
   - title: '🐛 Bug Fixes'
+    exclusive: true
     when:
       labels:
         - bug
         - fix
+  - title: '📦 Dependencies'
+    exclusive: true
+    when:
+      label: dependencies
+  - title: '⚙️ CI/CD'
+    exclusive: true
+    when:
+      label: github_actions
   - title: '🔨 Maintenance'
+    exclusive: true
     when:
       labels:
         - chore
         - refactor
-  - title: '📦 Dependencies'
-    when:
-      label: dependencies
-  - title: '⚙️ CI/CD'
-    when:
-      label: github_actions
   - title: '🧪 Samples'
+    exclusive: true
     when:
       labels:
         - samples
         - owin
   - title: '📝 Documentation'
+    exclusive: true
     when:
       label: documentation
   - title: Misc
+    exclusive: true
     when:
       label: '*'
   - type: pre-exclude
     when:
       label: ignore-for-release
   - type: version-resolver
+    exclusive: true
     semver-increment: major
     when:
       label: breaking
   - type: version-resolver
+    exclusive: true
     semver-increment: minor
     when:
       labels:
         - feature
         - enhancement
   - type: version-resolver
+    exclusive: true
     semver-increment: patch
     when:
       labels:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,15 +58,17 @@ Open in VS Code with the [Dev Containers](https://marketplace.visualstudio.com/i
    dotnet test --filter "FullyQualifiedName!~E2E"
    ```
 
-4. **Apply a label** to your PR (required for release-drafter to categorize it):
+4. **Apply one primary label** to your PR (required; release-drafter puts each PR in the first matching group):
 
    | Label                      | When to use              |
    | -------------------------- | ------------------------ |
    | `breaking`                 | Breaking API change      |
    | `feature` / `enhancement`  | New functionality        |
    | `bug` / `fix`              | Bug fix                  |
-   | `chore` / `refactor`       | Internal cleanup         |
    | `dependencies`             | Dependency updates       |
+   | `github_actions`           | CI / workflow changes    |
+   | `chore` / `refactor`       | Internal cleanup         |
+   | `samples`                  | Sample apps only         |
    | `documentation`            | Docs only                |
    | `ignore-for-release`       | Not noteworthy for users |
 


### PR DESCRIPTION
# Pull Request

## Description

Release notes were listing the same PR under several headings (see [v5.8.1](https://github.com/akunzai/GSS.Authentication.CAS/releases/tag/v5.8.1): #1012 in Bug Fixes + Samples, #1007 in four groups, #1002 in Bug Fixes + Dependencies).

**Cause:** `actions/labeler` stacked area labels (`samples` on `owin/**` and `samples/**`, `documentation` on any `*.md`, `github_actions` on every `.github/*.yml`) while release-drafter matched every category independently.

**Change:**

- Set `exclusive: true` on changelog (and version-resolver) categories. First match wins, in this order: breaking → feature → bug → dependencies → CI → chore → samples → docs → misc.
- Narrow labeler: `samples` = `samples/**` only; `documentation` = `docs/**` or `docs?/` branch; `github_actions` = workflows or `ci/` branch; add `chore/` branch.
- Document the one-primary-label rule in `CONTRIBUTING.md`.

v5.8.1 notes and the stacked labels on #1012 / #1007 / #1002 / #1001 are cleaned up in the same change set (release + PR labels, not this diff).

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (requires major version bump)
- [ ] Refactoring / maintenance
- [ ] Documentation update
- [ ] Dependency update
- [x] CI/CD change

## Checklist

- [x] I have applied an appropriate **PR label** (required for release notes)
- [ ] `dotnet build -c Release` passes with no warnings
- [ ] `dotnet test --filter "FullyQualifiedName!~E2E"` passes
- [ ] Added or updated tests for behavior changes
- [ ] Public API changes include XML documentation comments