### PR TITLE
build(deps): bump xunit packages to 4.0.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,7 +70,7 @@
     <PackageVersion Include="Microsoft.Playwright" Version="$(PlaywrightVersion)" />
     <PackageVersion Include="Microsoft.Playwright.Xunit" Version="$(PlaywrightVersion)" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0" />
+    <PackageVersion Include="xunit.v3" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/owin/GSS.Authentication.CAS.Owin.Tests/GSS.Authentication.CAS.Owin.Tests.csproj
+++ b/owin/GSS.Authentication.CAS.Owin.Tests/GSS.Authentication.CAS.Owin.Tests.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="coverlet.collector" VersionOverride="6.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />
+    <PackageReference Include="xunit.v3" VersionOverride="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" VersionOverride="3.1.5" PrivateAssets="All" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -7,6 +7,7 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
   </PropertyGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">


### PR DESCRIPTION
Bumps `xunit.v3` and `xunit.runner.visualstudio` to 4.0.0 while pinning OWIN tests to the previous version.

### Release Notes
- https://xunit.net/releases/v3/4.0.0
- https://xunit.net/releases/visualstudio/4.0.0

### Changes
- Updated `xunit.v3` and `xunit.runner.visualstudio` to `4.0.0` in `Directory.Packages.props`.
- Added `VersionOverride` in [GSS.Authentication.CAS.Owin.Tests.csproj](file:///Users/akunzai/code/GSS.Authentication.CAS/owin/GSS.Authentication.CAS.Owin.Tests/GSS.Authentication.CAS.Owin.Tests.csproj) to retain `xunit.v3` 3.2.2 and `xunit.runner.visualstudio` 3.1.5 for .NET Framework 4.8.
- Set `<IsTestingPlatformApplication>false</IsTestingPlatformApplication>` in [Directory.Build.props](file:///Users/akunzai/code/GSS.Authentication.CAS/test/Directory.Build.props) to maintain compatibility with VSTest test runner and code coverage collection on .NET 10 SDK.