### PR TITLE
build(test): migrate to Microsoft.Testing.Platform runner and native code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+codecov:
+  notify:
+    after_n_builds: 2
+
+comment:
+  after_n_builds: 2
+
+flag_management:
+  default_rules:
+    carryforward: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,11 @@ updates:
       interval: weekly
     cooldown:
       default-days: 3
+    ignore:
+      - dependency-name: "coverlet.collector"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
     groups:
       aspnetcore:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,6 +53,7 @@ updates:
       test-sdk:
         patterns:
           - Microsoft.NET.Test.Sdk
+          - Microsoft.Testing.*
           - Microsoft.TestPlatform.ObjectModel
       xunit:
         patterns:

--- a/.github/workflows/build-owin.yml
+++ b/.github/workflows/build-owin.yml
@@ -49,6 +49,8 @@ jobs:
           dotnet tool restore
           dotnet tool run reportgenerator
       - uses: codecov/codecov-action@v7
+        with:
+          flags: owin
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       - name: Check for changes in web.config

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,5 +45,7 @@ jobs:
           dotnet tool run reportgenerator
           [[ -f "./coverage/Summary.txt" ]] && cat "./coverage/Summary.txt"
       - uses: codecov/codecov-action@v7
+        with:
+          flags: core
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
           dotnet build -c Release
       - name: Test
         run: |
-          dotnet test --collect:"XPlat Code Coverage" --filter "FullyQualifiedName!~E2E"
+          dotnet test --coverage --coverage-output-format cobertura --filter "FullyQualifiedName!~E2E" --ignore-exit-code 8
           dotnet tool restore
           dotnet tool run reportgenerator
           [[ -f "./coverage/Summary.txt" ]] && cat "./coverage/Summary.txt"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -246,7 +246,7 @@ jobs:
 
       - name: Run E2E Tests
         if: steps.check.outputs.run == 'true'
-        run: dotnet test test/GSS.Authentication.CAS.E2E.Tests --logger "trx;LogFileName=test-results-${{ matrix.name }}.trx" --filter "FullyQualifiedName~${{ matrix.filter }}"
+        run: dotnet test test/GSS.Authentication.CAS.E2E.Tests --report-trx --report-trx-filename "test-results-${{ matrix.name }}.trx" --results-directory test/GSS.Authentication.CAS.E2E.Tests/TestResults --filter "FullyQualifiedName~${{ matrix.filter }}" --ignore-exit-code 8
 
       - name: Upload test results
         uses: actions/upload-artifact@v7

--- a/.netconfig
+++ b/.netconfig
@@ -1,5 +1,5 @@
 ; https://github.com/danielpalme/ReportGenerator
 [ReportGenerator]
-	reports = "**/coverage.cobertura.xml"
+	reports = "**/*.cobertura.xml"
 	targetdir = "coverage"
 	reporttypes = Cobertura,TextSummary

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,10 @@ CAS 1.0/2.0/3.0 authentication middleware for ASP.NET Core and OWIN/Katana. NuGe
 
 ```shell
 dotnet build
-dotnet test --filter "FullyQualifiedName!~E2E"
-dotnet test --filter "FullyQualifiedName~Cas20ServiceTicketValidatorTests.ValidateAsync"
+dotnet test --filter "FullyQualifiedName!~E2E" --ignore-exit-code 8
+dotnet test --coverage --coverage-output-format cobertura --filter "FullyQualifiedName!~E2E" --ignore-exit-code 8
+dotnet tool restore && dotnet tool run reportgenerator
+dotnet test --filter "Cas20ServiceTicketValidationTests" --ignore-exit-code 8
 cd owin && msbuild -noLogo -verbosity:minimal -restore   # Windows + MSBuild only
 aube lint && aube build                                   # samples/AspNetCoreReactSample/ClientApp
 ```

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -57,6 +57,8 @@
     <PackageVersion Include="Microsoft.Owin.Security.Cookies" Version="$(MicrosoftOwinVersion)" />
     <PackageVersion Include="Microsoft.Owin.Security.OpenIdConnect" Version="$(MicrosoftOwinVersion)" />
     <PackageVersion Include="Microsoft.Owin.Testing" Version="$(MicrosoftOwinVersion)" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.10.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.3.3" />
     <PackageVersion Include="Microsoft.TestPlatform.ObjectModel" Version="$(MicrosoftTestSdkVersion)" />
     <PackageVersion Include="NSubstitute" Version="6.1.0" />
     <PackageVersion Include="MSBuild.Microsoft.VisualStudio.Web.targets" Version="14.0.0.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="System.Text.Json" Version="$(SystemPackagesVersion)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.AspNet.Mvc" Version="5.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="$(MicrosoftAspNetCoreVersion)" />

--- a/global.json
+++ b/global.json
@@ -3,5 +3,8 @@
     "version": "10.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
+  },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
   }
 }

--- a/owin/GSS.Authentication.CAS.Owin.Tests/GSS.Authentication.CAS.Owin.Tests.csproj
+++ b/owin/GSS.Authentication.CAS.Owin.Tests/GSS.Authentication.CAS.Owin.Tests.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.Owin.Testing" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="System.Text.Json" />
-    <PackageReference Include="coverlet.collector" VersionOverride="6.0.4" />
+    <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" VersionOverride="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" VersionOverride="3.1.5" PrivateAssets="All" />

--- a/owin/global.json
+++ b/owin/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "VSTest"
+  }
+}

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -7,11 +7,11 @@
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <IsTestingPlatformApplication>false</IsTestingPlatformApplication>
   </PropertyGroup>
 
   <ItemGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
-    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" />


### PR DESCRIPTION
Migrates the test infrastructure to the native Microsoft.Testing.Platform (MTP) test runner and code coverage collection.

### Changes
- **MTP Runner**: Added `"test": { "runner": "Microsoft.Testing.Platform" }` in [global.json](file:///Users/akunzai/code/GSS.Authentication.CAS/global.json) and isolated OWIN with `"test": { "runner": "VSTest" }` in [owin/global.json](file:///Users/akunzai/code/GSS.Authentication.CAS/owin/global.json).
- **Code Coverage & Reporting**: Replaced `coverlet.collector` with `Microsoft.Testing.Extensions.CodeCoverage` (18.10.0) and `Microsoft.Testing.Extensions.TrxReport` (2.3.3) in [Directory.Packages.props](file:///Users/akunzai/code/GSS.Authentication.CAS/Directory.Packages.props) and [test/Directory.Build.props](file:///Users/akunzai/code/GSS.Authentication.CAS/test/Directory.Build.props).
- **Configuration & Workflows**:
  - Updated [.netconfig](file:///Users/akunzai/code/GSS.Authentication.CAS/.netconfig) report glob pattern to `**/*.cobertura.xml`.
  - Updated [.github/workflows/build.yml](file:///Users/akunzai/code/GSS.Authentication.CAS/.github/workflows/build.yml) to use `--coverage --coverage-output-format cobertura --filter "FullyQualifiedName!~E2E" --ignore-exit-code 8`.
  - Updated [.github/workflows/e2e-tests.yml](file:///Users/akunzai/code/GSS.Authentication.CAS/.github/workflows/e2e-tests.yml) for MTP TRX arguments and `--ignore-exit-code 8`.
  - Updated [.github/dependabot.yml](file:///Users/akunzai/code/GSS.Authentication.CAS/.github/dependabot.yml) and [AGENTS.md](file:///Users/akunzai/code/GSS.Authentication.CAS/AGENTS.md) test commands.