### PR TITLE
feat(owin): support customizing the CAS login redirect URL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 CAS 1.0/2.0/3.0 authentication middleware for ASP.NET Core and OWIN/Katana. NuGet: `GSS.Authentication.CAS.{Core,AspNetCore,Owin}`.
 
+## Language
+
+All repo-facing content — code comments, commit messages, PR/issue titles and bodies, docs — MUST be written in English, regardless of the conversation language used to produce it.
+
 ## Commands
 
 ```shell
@@ -29,6 +33,7 @@ Pinned in `@mise.toml`:
   - `@test/GSS.Authentication.CAS.Core.Tests/Cas20ServiceTicketValidationTests.cs`
   - `@test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationMiddlewareTests.cs`
 - Conventions: Central Package Management (CPM) in `@Directory.Packages.props` (never `Version=` in `.csproj`).
+- Agent skills config: issues on GitHub (`@docs/agents/issue-tracker.md`), triage labels (`@docs/agents/triage-labels.md`), domain docs layout (`@docs/agents/domain.md`).
 
 ## Constraints
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Pinned in `@mise.toml`:
   - `@test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationMiddlewareTests.cs`
 - Conventions: Central Package Management (CPM) in `@Directory.Packages.props` (never `Version=` in `.csproj`).
 - Agent skills config: issues on GitHub (`@docs/agents/issue-tracker.md`), triage labels (`@docs/agents/triage-labels.md`), domain docs layout (`@docs/agents/domain.md`).
+- Gotchas: `@docs/lessons-learned.md` (e.g. running OWIN tests locally via Mono).
 
 ## Constraints
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists: it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`**: read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```text
+/
+├── CONTEXT.md
+├── docs/adr/
+│   └── 0001-....md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal: either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-000X (...), but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo (`akunzai/GSS.Authentication.CAS`) live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either: resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies**, the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only, the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me`, the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,13 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning |
+| --- | --- | --- |
+| `needs-triage` | `needs-triage` | Maintainer needs to evaluate this issue |
+| `needs-info` | `needs-info` | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent` | Fully specified, ready for an AFK agent |
+| `ready-for-human` | `ready-for-human` | Requires human implementation |
+| `wontfix` | `wontfix` | Will not be actioned |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.

--- a/docs/lessons-learned.md
+++ b/docs/lessons-learned.md
@@ -1,0 +1,8 @@
+# Lessons Learned
+
+## Running OWIN tests locally on Apple Silicon (arm64) Mac via Mono
+
+`owin/GSS.Authentication.CAS.Owin.Tests` targets `net48` and needs Mono to run outside Windows/MSBuild (`dotnet build` compiles it fine on macOS; `dotnet test` needs Mono to execute the resulting `.exe`).
+
+- `dotnet test --filter "..."` does not work under Mono here: the xunit.v3 console runner ignores/misinterprets `--filter` and just prints its own `--help` instead of filtering. Run the full test project (or use the runner's own filter flags) instead of relying on `--filter`.
+- On Apple Silicon (arm64) Mono 6.12, `CasAuthenticationMiddlewareTests.SingleSignOut_ShouldRedirectToCasServer` fails even on an unmodified `main` — confirmed by running the same test from a `main` worktree. It's a pre-existing Mono-on-arm64-vs-.NET difference in how `Request.Scheme`/`Request.Host` resolve under `Microsoft.Owin.Testing.TestServer`, causing `BuildRedirectUriIfRelative` to treat an absolute URL as relative. Not a regression signal on that architecture; verify by diffing against `main` under the same Mono build before treating a failure here as real.

--- a/owin/GSS.Authentication.CAS.Owin.Tests/CasAuthenticationMiddlewareTests.cs
+++ b/owin/GSS.Authentication.CAS.Owin.Tests/CasAuthenticationMiddlewareTests.cs
@@ -407,6 +407,78 @@ namespace GSS.Authentication.CAS.Owin.Tests
         }
 
         [Fact]
+        public async Task SignInChallenge_WithCustomProvider_ShouldAppendCustomQueryParameter()
+        {
+            // Arrange
+            using var server = CreateServer(options =>
+            {
+                options.CasServerUrlBase = CasServerUrlBase;
+                options.Provider = new CasAuthenticationProvider
+                {
+                    OnRedirectToIdentityProviderForSignIn = context =>
+                    {
+                        context.RedirectUri =
+                            QueryHelpers.AddQueryString(context.RedirectUri, "login_hint", "user@example.org");
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+
+            // Act
+            using var response = await server.HttpClient.GetAsync("/challenge", TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+            var query = QueryHelpers.ParseQuery(response.Headers.Location.Query);
+            Assert.Equal("user@example.org", query["login_hint"]);
+        }
+
+        [Fact]
+        public async Task SignInChallenge_WhenRedirectHandled_ShouldSkipDefaultRedirect()
+        {
+            // Arrange
+            const string customLoginPath = "/custom-login";
+            using var server = CreateServer(options =>
+            {
+                options.CasServerUrlBase = CasServerUrlBase;
+                options.Provider = new CasAuthenticationProvider
+                {
+                    OnRedirectToIdentityProviderForSignIn = context =>
+                    {
+                        context.Response.Redirect(customLoginPath);
+                        context.HandleResponse();
+                        return Task.CompletedTask;
+                    }
+                };
+            });
+
+            // Act
+            using var response = await server.HttpClient.GetAsync("/challenge", TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+            Assert.Equal(customLoginPath, response.Headers.Location.OriginalString);
+        }
+
+        [Fact]
+        public async Task SignInChallenge_WithPlainProvider_ShouldRedirectToCasLoginEndpointUnchanged()
+        {
+            // Arrange
+            using var server = CreateServer(options =>
+            {
+                options.CasServerUrlBase = CasServerUrlBase;
+                options.Provider = Substitute.For<ICasAuthenticationProvider>();
+            });
+
+            // Act
+            using var response = await server.HttpClient.GetAsync("/challenge", TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+            Assert.StartsWith(CasServerUrlBase + Constants.Paths.Login, response.Headers.Location.AbsoluteUri);
+        }
+
+        [Fact]
         public async Task SingleSignOut_ShouldRedirectToCasServer()
         {
             // Arrange

--- a/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
@@ -234,11 +234,11 @@ namespace GSS.Authentication.CAS.Owin
         /// Handles SignIn
         /// </summary>
         /// <returns></returns>
-        protected override Task ApplyResponseChallengeAsync()
+        protected override async Task ApplyResponseChallengeAsync()
         {
             if (Response.StatusCode != 401)
             {
-                return Task.CompletedTask;
+                return;
             }
 
             var challenge = Helper.LookupChallenge(Options.AuthenticationType, Options.AuthenticationMode);
@@ -262,10 +262,18 @@ namespace GSS.Authentication.CAS.Owin
                 var authorizationEndpoint =
                     $"{Options.CasServerUrlBase}/login?service={Uri.EscapeDataString(returnTo)}";
 
-                Response.Redirect(authorizationEndpoint);
-            }
+                var redirectContext = new CasRedirectContext(Context, null) { RedirectUri = authorizationEndpoint };
+                if (Options.Provider is CasAuthenticationProvider provider)
+                {
+                    await provider.RedirectToIdentityProviderForSignIn(redirectContext).ConfigureAwait(false);
+                    if (redirectContext.Handled)
+                    {
+                        return;
+                    }
+                }
 
-            return Task.CompletedTask;
+                Response.Redirect(redirectContext.RedirectUri);
+            }
         }
 
         private string BuildRedirectUri(string path)

--- a/src/GSS.Authentication.CAS.Owin/Events/CasAuthenticationProvider.cs
+++ b/src/GSS.Authentication.CAS.Owin/Events/CasAuthenticationProvider.cs
@@ -29,16 +29,26 @@ namespace GSS.Authentication.CAS.Owin
         /// </summary>
         public Func<CasRedirectContext, Task> OnRedirectToIdentityProviderForSignOut { get; set; } = _ => Task.CompletedTask;
 
+        /// <summary>
+        /// Invoked before redirecting to the identity provider to sign in.
+        /// </summary>
+        public Func<CasRedirectContext, Task> OnRedirectToIdentityProviderForSignIn { get; set; } = _ => Task.CompletedTask;
+
         public Func<CasRemoteFailureContext, Task> OnRemoteFailure { get; set; } = _ => Task.CompletedTask;
 
         public virtual Task CreatingTicket(CasCreatingTicketContext context) => OnCreatingTicket(context);
 
         public virtual Task RedirectToAuthorizationEndpoint(CasRedirectToAuthorizationEndpointContext context) => OnRedirectToAuthorizationEndpoint(context);
-        
+
         /// <summary>
         /// Invoked before redirecting to the identity provider to sign out.
         /// </summary>
         public virtual Task RedirectToIdentityProviderForSignOut(CasRedirectContext context) => OnRedirectToIdentityProviderForSignOut(context);
+
+        /// <summary>
+        /// Invoked before redirecting to the identity provider to sign in.
+        /// </summary>
+        public virtual Task RedirectToIdentityProviderForSignIn(CasRedirectContext context) => OnRedirectToIdentityProviderForSignIn(context);
 
         public Task RemoteFailure(CasRemoteFailureContext context) => OnRemoteFailure(context);
     }


### PR DESCRIPTION
## Summary
- Add `CasAuthenticationProvider.RedirectToIdentityProviderForSignIn`, a virtual hook invoked right before `ApplyResponseChallengeAsync` redirects to the CAS login page, so consumers can mutate the redirect URL (e.g. append a `login_hint`-style query parameter) or short-circuit the redirect via `HandleResponse()`.
- The hook is added only to the concrete `CasAuthenticationProvider` class, not to `ICasAuthenticationProvider`, to avoid a breaking change for direct interface implementers; `CasAuthenticationHandler` falls back to the original `Response.Redirect(...)` behavior when `Options.Provider` isn't a `CasAuthenticationProvider`.
- Record two Mono/arm64 testing gotchas in `docs/lessons-learned.md` found while validating this change locally.
- Configure agent-skills issue tracker/triage-label/domain-doc conventions (`docs/agents/*.md`) and add an English-only convention for repo-facing content to `AGENTS.md`.

Closes #1027

## Test plan
- [x] `dotnet build` (main solution + OWIN via `dotnet build owin/GSS.Authentication.CAS.Owin.Tests`)
- [x] `dotnet test --filter "FullyQualifiedName!~E2E"` (258 passed)
- [x] `dotnet test owin/GSS.Authentication.CAS.Owin.Tests` under Mono on Apple Silicon — all new/existing challenge tests pass; the one unrelated pre-existing failure (`SingleSignOut_ShouldRedirectToCasServer`) reproduces identically on unmodified `main` under the same Mono build (see `docs/lessons-learned.md`)
- [x] `/code-review` (Standards + Spec axes) — no unresolved findings; one flagged "hard violation" (interface not extended) is the deliberate, spec-approved trade-off