### PR TITLE
fix: avoid double slash in CAS login redirect URL

### DIFF
--- a/owin/GSS.Authentication.CAS.Owin.Tests/CasAuthenticationMiddlewareTests.cs
+++ b/owin/GSS.Authentication.CAS.Owin.Tests/CasAuthenticationMiddlewareTests.cs
@@ -461,6 +461,20 @@ namespace GSS.Authentication.CAS.Owin.Tests
         }
 
         [Fact]
+        public async Task SignInChallenge_WithTrailingSlashInCasServerUrlBase_ShouldNotProduceDoubleSlash()
+        {
+            // Arrange
+            using var server = CreateServer(options => options.CasServerUrlBase = CasServerUrlBase + "/");
+
+            // Act
+            using var response = await server.HttpClient.GetAsync("/challenge", TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+            Assert.StartsWith(CasServerUrlBase + Constants.Paths.Login + "?", response.Headers.Location.AbsoluteUri);
+        }
+
+        [Fact]
         public async Task SignInChallenge_WithPlainProvider_ShouldRedirectToCasLoginEndpointUnchanged()
         {
             // Arrange

--- a/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs
@@ -138,8 +138,9 @@ public class CasAuthenticationHandler : RemoteAuthenticationHandler<CasAuthentic
             callbackUri = QueryHelpers.AddQueryString(callbackUri, State, state);
         }
 
-        var redirectUri = Options.CasServerUrlBase + Constants.Paths.Login +
-                          $"?{Constants.Parameters.Service}={Uri.EscapeDataString(callbackUri)}";
+        var redirectUri = QueryHelpers.AddQueryString(
+            $"{Options.CasServerUrlBase.TrimEnd('/')}{Constants.Paths.Login}",
+            Constants.Parameters.Service, callbackUri);
 
         var redirectContext = new RedirectContext<CasAuthenticationOptions>(
             Context, Scheme, Options,

--- a/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
@@ -259,8 +259,9 @@ namespace GSS.Authentication.CAS.Owin
                 var returnTo = QueryHelpers.AddQueryString(BuildRedirectUri(Options.CallbackPath.Value), State,
                     Options.StateDataFormat.Protect(state));
 
-                var authorizationEndpoint =
-                    $"{Options.CasServerUrlBase}/login?service={Uri.EscapeDataString(returnTo)}";
+                var authorizationEndpoint = QueryHelpers.AddQueryString(
+                    $"{Options.CasServerUrlBase.TrimEnd('/')}{Constants.Paths.Login}",
+                    Constants.Parameters.Service, returnTo);
 
                 var redirectContext = new CasRedirectContext(Context, null) { RedirectUri = authorizationEndpoint };
                 if (Options.Provider is CasAuthenticationProvider provider)

--- a/test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationMiddlewareTests.cs
+++ b/test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationMiddlewareTests.cs
@@ -83,6 +83,25 @@ public class CasAuthenticationMiddlewareTests
     }
 
     [Fact]
+    public async Task SignInChallenge_WithTrailingSlashInCasServerUrlBase_ShouldNotProduceDoubleSlash()
+    {
+        // Arrange
+        using var host = CreateHost(options => options.CasServerUrlBase = CasServerUrlBase + "/");
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync(CookieAuthenticationDefaults.LoginPath,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.StartsWith(CasServerUrlBase + Constants.Paths.Login + "?",
+            response.Headers.Location?.AbsoluteUri ?? string.Empty);
+    }
+
+    [Fact]
     public async Task SignInChallenge_WithoutTicketInCallbackQuery_ShouldThrows()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- `Options.CasServerUrlBase` with a trailing slash produced a malformed redirect URL (e.g. `.../cas//login?...`) in both the OWIN (`CasAuthenticationHandler.ApplyResponseChallengeAsync`) and ASP.NET Core (`CasAuthenticationHandler.HandleChallengeAsync`) packages, since the login redirect URL was built via plain string concatenation.
- Fix both handlers by trimming the trailing slash and building the query string via `QueryHelpers.AddQueryString`, consistent with how each handler already builds its sign-out redirect URL.
- Scope widened from OWIN-only (as originally filed) to both packages after `/code-review` on the OWIN fix surfaced the identical unfixed pattern in the ASP.NET Core handler; issue #1029 was updated to match.

Closes #1029

## Test plan
- [x] `dotnet build` (0 warnings)
- [x] `dotnet test --filter "FullyQualifiedName!~E2E"` (260 passed, includes new `SignInChallenge_WithTrailingSlashInCasServerUrlBase_ShouldNotProduceDoubleSlash` regression tests in both the OWIN and ASP.NET Core test suites)
- [ ] OWIN test suite under Mono (local Mono install is currently unavailable on this machine — relying on CI)