### PR TITLE
feat: add CAS 2.0/3.0 Proxy support (PGT/PGTIOU, /proxy, /proxyValidate)

### DIFF
--- a/owin/GSS.Authentication.CAS.Owin.Tests/CasAuthenticationMiddlewareTests.cs
+++ b/owin/GSS.Authentication.CAS.Owin.Tests/CasAuthenticationMiddlewareTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Security.Claims;
+using GSS.Authentication.CAS.Proxy;
 using GSS.Authentication.CAS.Security;
 using GSS.Authentication.CAS.Validation;
 using Microsoft.AspNetCore.WebUtilities;
@@ -118,6 +119,57 @@ namespace GSS.Authentication.CAS.Owin.Tests
             var bodyText = await authorizedResponse.Content.ReadAsStringAsync();
             Assert.Equal(principal.GetPrincipalName(), bodyText);
             await ticketValidator.Received(1).ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+
+        [Fact]
+        public async Task ProxyCallback_WithPgtIdAndPgtIou_ShouldStoreInProxyGrantingTicketStore()
+        {
+            // Arrange
+            var store = new InMemoryProxyGrantingTicketStore();
+            using var server = CreateServer(options =>
+            {
+                options.CasServerUrlBase = CasServerUrlBase;
+                options.ProxyCallbackPath = new Microsoft.Owin.PathString("/proxyCallback");
+                options.ProxyGrantingTicketStore = store;
+            });
+
+            // Act
+            using var response = await server.HttpClient.GetAsync("/proxyCallback?pgtId=PGT-1-abc&pgtIou=PGTIOU-1-abc",
+                TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("PGT-1-abc", await store.GetAsync("PGTIOU-1-abc", TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public async Task SignInChallenge_WithProxyCallbackPathConfigured_ShouldRequestProxyGrantingTicket()
+        {
+            // Arrange
+            var ticketValidator = Substitute.For<IServiceTicketValidator>();
+            var ticket = Guid.NewGuid().ToString();
+            var principal = new CasPrincipal(new Assertion(Guid.NewGuid().ToString()), CasDefaults.AuthenticationType);
+            ticketValidator
+                .ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>(), Arg.Any<string>())
+                .Returns(Task.FromResult<ICasPrincipal?>(principal));
+            using var server = CreateServer(options =>
+            {
+                options.ServiceTicketValidator = ticketValidator;
+                options.CasServerUrlBase = CasServerUrlBase;
+                options.ProxyCallbackPath = new Microsoft.Owin.PathString("/proxyCallback");
+            });
+            using var challengeResponse = await server.HttpClient.GetAsync(CookieAuthenticationDefaults.LoginPath.Value, TestContext.Current.CancellationToken);
+            var query = QueryHelpers.ParseQuery(challengeResponse.Headers.Location.Query);
+            var validateUrl =
+                QueryHelpers.AddQueryString(query[Constants.Parameters.Service], Constants.Parameters.Ticket, ticket);
+
+            // Act
+            using var signInRequest = challengeResponse.GetRequestWithCookies(validateUrl);
+            await server.HttpClient.SendAsync(signInRequest, TestContext.Current.CancellationToken);
+
+            // Assert
+            await ticketValidator.Received(1).ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>(),
+                Arg.Is<string>(url => url != null && url.EndsWith("/proxyCallback", StringComparison.Ordinal)));
         }
 
         [Fact]

--- a/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs
@@ -58,7 +58,31 @@ public class CasAuthenticationHandler : RemoteAuthenticationHandler<CasAuthentic
             return await HandleSignOutCallbackAsync();
         }
 
+        if (Options.ProxyCallbackPath.HasValue && Options.ProxyCallbackPath == Request.Path)
+        {
+            return await HandleProxyCallbackAsync().ConfigureAwait(false);
+        }
+
         return await base.HandleRequestAsync();
+    }
+
+    /// <summary>
+    /// Receives the Proxy Granting Ticket (<c>pgtId</c>/<c>pgtIou</c>) CAS delivers to the <c>pgtUrl</c> callback.
+    /// See CAS Protocol Specification §2.5.4/§3.3/§3.4.
+    /// </summary>
+    private async Task<bool> HandleProxyCallbackAsync()
+    {
+        var proxyGrantingTicketId = Request.Query[Constants.Parameters.ProxyGrantingTicketId];
+        var proxyGrantingTicketIou = Request.Query[Constants.Parameters.ProxyGrantingTicketIou];
+        if (!string.IsNullOrEmpty(proxyGrantingTicketId) && !string.IsNullOrEmpty(proxyGrantingTicketIou))
+        {
+            await Options.ProxyGrantingTicketStore
+                .StoreAsync(proxyGrantingTicketIou!, proxyGrantingTicketId!, Context.RequestAborted)
+                .ConfigureAwait(false);
+        }
+
+        Response.StatusCode = 200;
+        return true;
     }
 
     /// <summary>
@@ -174,8 +198,19 @@ public class CasAuthenticationHandler : RemoteAuthenticationHandler<CasAuthentic
         }
 
         var callbackUri = BuildRedirectUri($"{Options.CallbackPath}?{State}={Uri.EscapeDataString(state!)}");
+        var proxyCallbackUrl = Options.ProxyCallbackPath.HasValue
+            ? BuildRedirectUri(Options.ProxyCallbackPath)
+            : null;
+        if (proxyCallbackUrl != null && !proxyCallbackUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+        {
+            Logger.LogWarning(
+                "ProxyCallbackPath is configured but the resulting URL '{ProxyCallbackUrl}' is not HTTPS; CAS requires pgtUrl to be HTTPS and will not issue a Proxy Granting Ticket to it.",
+                proxyCallbackUrl);
+        }
+
         var principal = await Options.ServiceTicketValidator
-            .ValidateAsync(serviceTicket!, callbackUri, Context.RequestAborted).ConfigureAwait(false);
+            .ValidateAsync(serviceTicket!, callbackUri, Context.RequestAborted, proxyCallbackUrl)
+            .ConfigureAwait(false);
 
         if (principal == null)
         {

--- a/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationOptions.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using GSS.Authentication.CAS.Proxy;
 using GSS.Authentication.CAS.Validation;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
@@ -37,6 +38,21 @@ public class CasAuthenticationOptions : RemoteAuthenticationOptions, ICasOptions
     /// </summary>
     /// <remarks>This URI can be out of the application's domain. By default it points to the root.</remarks>
     public string SignedOutRedirectUri { get; set; } = "/";
+
+    /// <summary>
+    /// The request path within the application's base path where CAS will deliver a Proxy Granting Ticket
+    /// (<c>pgtId</c>/<c>pgtIou</c>) after successfully validating a service ticket for which a <c>pgtUrl</c> was
+    /// requested. Must be reachable over HTTPS by the CAS server. Leave unset (the default) to not request PGTs.
+    /// See CAS Protocol Specification §2.5.4/§3.3/§3.4.
+    /// </summary>
+    public PathString ProxyCallbackPath { get; set; }
+
+    /// <summary>
+    /// Correlates the PGTIOU returned in the validation response with the real Proxy Granting Ticket delivered to
+    /// <see cref="ProxyCallbackPath"/>. Defaults to an in-memory, single-process store; provide a distributed
+    /// implementation for multi-instance deployments.
+    /// </summary>
+    public IProxyGrantingTicketStore ProxyGrantingTicketStore { get; set; } = new InMemoryProxyGrantingTicketStore();
 
     public new CasEvents Events
     {

--- a/src/GSS.Authentication.CAS.Core/CasOptionsExtensions.cs
+++ b/src/GSS.Authentication.CAS.Core/CasOptionsExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace GSS.Authentication.CAS
+{
+    internal static class CasOptionsExtensions
+    {
+        /// <summary>
+        /// The base URI of the CAS server, normalized to always end with a trailing slash so relative endpoint
+        /// paths (e.g. <c>serviceValidate</c>, <c>proxy</c>) combine into a single-slash-separated URL.
+        /// </summary>
+        public static Uri GetBaseUri(this ICasOptions options)
+        {
+            return new Uri(options.CasServerUrlBase +
+#if NETCOREAPP3_1_OR_GREATER
+            (options.CasServerUrlBase.EndsWith('/')
+#else
+            (options.CasServerUrlBase.EndsWith("/")
+#endif
+                                      ? string.Empty : "/"));
+        }
+    }
+}

--- a/src/GSS.Authentication.CAS.Core/Constants.cs
+++ b/src/GSS.Authentication.CAS.Core/Constants.cs
@@ -7,6 +7,10 @@ namespace GSS.Authentication.CAS
             public const string Service = "service";
 
             public const string Ticket = "ticket";
+
+            public const string ProxyGrantingTicketId = "pgtId";
+
+            public const string ProxyGrantingTicketIou = "pgtIou";
         }
 
         public static class Paths

--- a/src/GSS.Authentication.CAS.Core/Proxy/CasProxyTicketProvider.cs
+++ b/src/GSS.Authentication.CAS.Core/Proxy/CasProxyTicketProvider.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Net.Http;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace GSS.Authentication.CAS.Proxy
+{
+    /// <summary>
+    /// Default <see cref="IProxyTicketProvider"/> implementation, calling the CAS <c>/proxy</c> endpoint.
+    /// See https://apereo.github.io/cas/development/protocol/CAS-Protocol-Specification.html#27-proxy-cas-20
+    /// </summary>
+    public class CasProxyTicketProvider : IProxyTicketProvider
+    {
+        private static readonly XNamespace _namespace = "http://www.yale.edu/tp/cas";
+        private static readonly XName _proxySuccess = _namespace + "proxySuccess";
+        private static readonly XName _proxyFailure = _namespace + "proxyFailure";
+        private static readonly XName _proxyTicket = _namespace + "proxyTicket";
+
+        private readonly ICasOptions _options;
+        private readonly HttpClient _httpClient;
+
+        public CasProxyTicketProvider(ICasOptions options, HttpClient? httpClient = null)
+        {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
+            _httpClient = httpClient ?? new HttpClient();
+        }
+
+        /// <inheritdoc />
+        public async Task<string> GetProxyTicketAsync(string proxyGrantingTicket, string targetService,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(proxyGrantingTicket))
+                throw new ArgumentNullException(nameof(proxyGrantingTicket));
+            if (string.IsNullOrEmpty(targetService))
+                throw new ArgumentNullException(nameof(targetService));
+
+            var proxyUri = new Uri(_options.GetBaseUri(), "proxy");
+            var requestUri =
+                $"{proxyUri.AbsoluteUri}?pgt={Uri.EscapeDataString(proxyGrantingTicket)}&targetService={Uri.EscapeDataString(targetService)}";
+            var response = await _httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException(
+                    $"Failed to request a Proxy Ticket for target service [{targetService}] with error status [{(int)response.StatusCode}], please make sure your CAS server supports the proxy URI [{proxyUri}]");
+            }
+
+            var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+            var doc = XElement.Parse(responseBody);
+
+            var failureElement = doc.Element(_proxyFailure);
+            if (failureElement != null)
+            {
+                throw new AuthenticationException(failureElement.Value);
+            }
+
+            var successElement = doc.Element(_proxySuccess);
+            var proxyTicket = successElement?.Element(_proxyTicket)?.Value;
+            if (string.IsNullOrWhiteSpace(proxyTicket))
+            {
+                throw new AuthenticationException(
+                    $"CAS server returned an unrecognized response for the proxy request: {responseBody}");
+            }
+
+            return proxyTicket!;
+        }
+    }
+}

--- a/src/GSS.Authentication.CAS.Core/Proxy/IProxyGrantingTicketStore.cs
+++ b/src/GSS.Authentication.CAS.Core/Proxy/IProxyGrantingTicketStore.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GSS.Authentication.CAS.Proxy
+{
+    /// <summary>
+    /// Correlates the PGTIOU returned in a ticket-validation response with the real Proxy Granting Ticket
+    /// delivered separately to the <c>pgtUrl</c> callback. See CAS Protocol Specification §2.5.4/§3.3/§3.4.
+    /// </summary>
+    public interface IProxyGrantingTicketStore
+    {
+        /// <summary>
+        /// Records the real Proxy Granting Ticket delivered to the <c>pgtUrl</c> callback, keyed by the PGTIOU
+        /// that will later be returned in the ticket-validation response.
+        /// </summary>
+        Task StoreAsync(string proxyGrantingTicketIou, string proxyGrantingTicket,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Looks up the real Proxy Granting Ticket for a PGTIOU, or <see langword="null"/> if none has been
+        /// recorded (e.g. the callback hasn't arrived yet, or was never requested).
+        /// </summary>
+        Task<string?> GetAsync(string proxyGrantingTicketIou, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a previously stored Proxy Granting Ticket, once it's no longer needed.
+        /// </summary>
+        Task RemoveAsync(string proxyGrantingTicketIou, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/GSS.Authentication.CAS.Core/Proxy/IProxyTicketProvider.cs
+++ b/src/GSS.Authentication.CAS.Core/Proxy/IProxyTicketProvider.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GSS.Authentication.CAS.Proxy
+{
+    /// <summary>
+    /// Exchanges a Proxy Granting Ticket for a Proxy Ticket via the CAS <c>/proxy</c> endpoint.
+    /// See CAS Protocol Specification §2.7.
+    /// </summary>
+    public interface IProxyTicketProvider
+    {
+        /// <summary>
+        /// Requests a Proxy Ticket for <paramref name="targetService"/>, using a previously obtained
+        /// Proxy Granting Ticket.
+        /// </summary>
+        /// <param name="proxyGrantingTicket">The real PGT, e.g. from <see cref="IProxyGrantingTicketStore"/>.</param>
+        /// <param name="targetService">The backend service the Proxy Ticket will be presented to.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>The issued Proxy Ticket.</returns>
+        /// <exception cref="System.Security.Authentication.AuthenticationException">
+        /// Thrown when CAS returns a <c>cas:proxyFailure</c> response.
+        /// </exception>
+        Task<string> GetProxyTicketAsync(string proxyGrantingTicket, string targetService,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/GSS.Authentication.CAS.Core/Proxy/InMemoryProxyGrantingTicketStore.cs
+++ b/src/GSS.Authentication.CAS.Core/Proxy/InMemoryProxyGrantingTicketStore.cs
@@ -1,0 +1,38 @@
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GSS.Authentication.CAS.Proxy
+{
+    /// <summary>
+    /// Default, single-process <see cref="IProxyGrantingTicketStore"/>. Register a distributed implementation
+    /// for multi-instance deployments, since the PGTIOU callback and the validation response that references it
+    /// may land on different instances.
+    /// </summary>
+    public class InMemoryProxyGrantingTicketStore : IProxyGrantingTicketStore
+    {
+        private readonly ConcurrentDictionary<string, string> _tickets = new();
+
+        /// <inheritdoc />
+        public Task StoreAsync(string proxyGrantingTicketIou, string proxyGrantingTicket,
+            CancellationToken cancellationToken = default)
+        {
+            _tickets[proxyGrantingTicketIou] = proxyGrantingTicket;
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public Task<string?> GetAsync(string proxyGrantingTicketIou, CancellationToken cancellationToken = default)
+        {
+            _tickets.TryGetValue(proxyGrantingTicketIou, out var ticket);
+            return Task.FromResult<string?>(ticket);
+        }
+
+        /// <inheritdoc />
+        public Task RemoveAsync(string proxyGrantingTicketIou, CancellationToken cancellationToken = default)
+        {
+            _tickets.TryRemove(proxyGrantingTicketIou, out _);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/GSS.Authentication.CAS.Core/Security/Assertion.cs
+++ b/src/GSS.Authentication.CAS.Core/Security/Assertion.cs
@@ -8,16 +8,32 @@ namespace GSS.Authentication.CAS.Security
     {
         public Assertion(
             string principalName,
-            IDictionary<string, StringValues>? attributes = null)
+            IDictionary<string, StringValues>? attributes = null,
+            string? proxyGrantingTicketIou = null,
+            IReadOnlyList<string>? proxies = null)
         {
             if (string.IsNullOrWhiteSpace(principalName))
                 throw new ArgumentNullException(nameof(principalName));
             PrincipalName = principalName;
             Attributes = attributes ?? new Dictionary<string, StringValues>();
+            ProxyGrantingTicketIou = proxyGrantingTicketIou;
+            Proxies = proxies ?? Array.Empty<string>();
         }
 
         public string PrincipalName { get; }
 
         public IDictionary<string, StringValues> Attributes { get; }
+
+        /// <summary>
+        /// The PGTIOU returned by CAS in the <c>cas:proxyGrantingTicket</c> element, correlating to the real
+        /// Proxy Granting Ticket delivered separately to the <c>pgtUrl</c> callback.
+        /// </summary>
+        public string? ProxyGrantingTicketIou { get; }
+
+        /// <summary>
+        /// The chain of proxying services, most-recently-visited proxy first, from the <c>cas:proxies</c> element.
+        /// Only populated when validating a Proxy Ticket via <c>/proxyValidate</c> or <c>/p3/proxyValidate</c>.
+        /// </summary>
+        public IReadOnlyList<string> Proxies { get; }
     }
 }

--- a/src/GSS.Authentication.CAS.Core/Validation/Cas20ProxyTicketValidator.cs
+++ b/src/GSS.Authentication.CAS.Core/Validation/Cas20ProxyTicketValidator.cs
@@ -1,0 +1,15 @@
+using System.Net.Http;
+
+namespace GSS.Authentication.CAS.Validation
+{
+    // see https://apereo.github.io/cas/development/protocol/CAS-Protocol-Specification.html#26-proxyvalidate-cas-20
+    public class Cas20ProxyTicketValidator : Cas20ServiceTicketValidator
+    {
+        public Cas20ProxyTicketValidator(
+            ICasOptions options,
+            HttpClient? httpClient = null)
+            : base("proxyValidate", options, httpClient)
+        {
+        }
+    }
+}

--- a/src/GSS.Authentication.CAS.Core/Validation/Cas20ServiceTicketValidator.cs
+++ b/src/GSS.Authentication.CAS.Core/Validation/Cas20ServiceTicketValidator.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Security.Authentication;
 using System.Xml.Linq;
@@ -15,6 +16,9 @@ namespace GSS.Authentication.CAS.Validation
         private static readonly XName _authenticationSuccess = _namespace + "authenticationSuccess";
         private static readonly XName _authenticationFailure = _namespace + "authenticationFailure";
         private static readonly XName _user = _namespace + "user";
+        private static readonly XName _proxyGrantingTicket = _namespace + "proxyGrantingTicket";
+        private static readonly XName _proxies = _namespace + "proxies";
+        private static readonly XName _proxy = _namespace + "proxy";
 
         public Cas20ServiceTicketValidator(
             ICasOptions options,
@@ -89,7 +93,10 @@ namespace GSS.Authentication.CAS.Validation
                 }
             }
 
-            var assertion = new Assertion(principalName, attributes);
+            var proxyGrantingTicketIou = successElement.Element(_proxyGrantingTicket)?.Value;
+            var proxies = successElement.Element(_proxies)?.Elements(_proxy).Select(e => e.Value).ToList();
+
+            var assertion = new Assertion(principalName, attributes, proxyGrantingTicketIou, proxies);
             return new CasPrincipal(assertion, Options.AuthenticationType);
         }
     }

--- a/src/GSS.Authentication.CAS.Core/Validation/Cas30ProxyTicketValidator.cs
+++ b/src/GSS.Authentication.CAS.Core/Validation/Cas30ProxyTicketValidator.cs
@@ -1,0 +1,15 @@
+using System.Net.Http;
+
+namespace GSS.Authentication.CAS.Validation
+{
+    // see https://apereo.github.io/cas/development/protocol/CAS-Protocol-Specification.html#29-p3proxyvalidate-cas-30
+    public class Cas30ProxyTicketValidator : Cas20ServiceTicketValidator
+    {
+        public Cas30ProxyTicketValidator(
+            ICasOptions options,
+            HttpClient? httpClient = null)
+            : base("p3/proxyValidate", options, httpClient)
+        {
+        }
+    }
+}

--- a/src/GSS.Authentication.CAS.Core/Validation/CasServiceTicketValidator.cs
+++ b/src/GSS.Authentication.CAS.Core/Validation/CasServiceTicketValidator.cs
@@ -24,23 +24,20 @@ namespace GSS.Authentication.CAS.Validation
         public virtual async Task<ICasPrincipal?> ValidateAsync(
             string ticket,
             string service,
-            CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default,
+            string? proxyCallbackUrl = null)
         {
             if (string.IsNullOrEmpty(ticket))
                 throw new ArgumentNullException(nameof(ticket));
             if (string.IsNullOrEmpty(service))
                 throw new ArgumentNullException(nameof(service));
-            var baseUri = new Uri(Options.CasServerUrlBase +
-#if NETCOREAPP3_1_OR_GREATER
-            (Options.CasServerUrlBase.EndsWith('/') 
-#else
-            (Options.CasServerUrlBase.EndsWith("/")
-#endif
-                                      ? string.Empty : "/"));
-            var validateUri = new Uri(baseUri, _suffix);
+            var validateUri = new Uri(Options.GetBaseUri(), _suffix);
             var requestUri =
-                new Uri(
-                    $"{validateUri.AbsoluteUri}?ticket={Uri.EscapeDataString(ticket)}&service={Uri.EscapeDataString(service)}");
+                $"{validateUri.AbsoluteUri}?ticket={Uri.EscapeDataString(ticket)}&service={Uri.EscapeDataString(service)}";
+            if (!string.IsNullOrEmpty(proxyCallbackUrl))
+            {
+                requestUri += $"&pgtUrl={Uri.EscapeDataString(proxyCallbackUrl)}";
+            }
             var response = await _httpClient.GetAsync(requestUri, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessStatusCode)
             {

--- a/src/GSS.Authentication.CAS.Core/Validation/IServiceTicketValidator.cs
+++ b/src/GSS.Authentication.CAS.Core/Validation/IServiceTicketValidator.cs
@@ -12,12 +12,17 @@ namespace GSS.Authentication.CAS.Validation
         /// <param name="ticket"></param>
         /// <param name="service"></param>
         /// <param name="cancellationToken"></param>
+        /// <param name="proxyCallbackUrl">
+        /// The HTTPS <c>pgtUrl</c> callback CAS should invoke with a Proxy Granting Ticket, if the caller wants one
+        /// issued for this validation. See CAS Protocol Specification §2.5.4.
+        /// </param>
         /// <returns></returns>
         /// <exception cref="System.Security.Authentication.AuthenticationException"></exception>
         /// <exception cref="System.Net.Http.HttpRequestException"></exception>
         /// <exception cref="System.UriFormatException"></exception>
         Task<ICasPrincipal?> ValidateAsync(string ticket,
             string service,
-            CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default,
+            string? proxyCallbackUrl = null);
     }
 }

--- a/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
@@ -7,6 +7,7 @@ using Microsoft.Owin.Infrastructure;
 using Microsoft.Owin.Logging;
 using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Infrastructure;
+using GSS.Authentication.CAS.Proxy;
 
 namespace GSS.Authentication.CAS.Owin
 {
@@ -36,7 +37,32 @@ namespace GSS.Authentication.CAS.Owin
                 return await InvokeReturnPathAsync().ConfigureAwait(false);
             }
 
+            if (Options.ProxyCallbackPath.HasValue && Options.ProxyCallbackPath == Request.Path)
+            {
+                return await HandleProxyCallbackAsync().ConfigureAwait(false);
+            }
+
             return false;
+        }
+
+        /// <summary>
+        /// Receives the Proxy Granting Ticket (<c>pgtId</c>/<c>pgtIou</c>) CAS delivers to the <c>pgtUrl</c> callback.
+        /// See CAS Protocol Specification §2.5.4/§3.3/§3.4.
+        /// </summary>
+        private async Task<bool> HandleProxyCallbackAsync()
+        {
+            var query = Request.Query;
+            var proxyGrantingTicketId = query[Constants.Parameters.ProxyGrantingTicketId];
+            var proxyGrantingTicketIou = query[Constants.Parameters.ProxyGrantingTicketIou];
+            if (!string.IsNullOrEmpty(proxyGrantingTicketId) && !string.IsNullOrEmpty(proxyGrantingTicketIou))
+            {
+                await Options.ProxyGrantingTicketStore
+                    .StoreAsync(proxyGrantingTicketIou, proxyGrantingTicketId, Request.CallCancelled)
+                    .ConfigureAwait(false);
+            }
+
+            Response.StatusCode = 200;
+            return true;
         }
 
         private Task<bool> HandleSignOutCallbackAsync()
@@ -168,7 +194,17 @@ namespace GSS.Authentication.CAS.Owin
             }
 
             var service = QueryHelpers.AddQueryString(BuildRedirectUri(Options.CallbackPath.Value), State, state);
-            var principal = await Options.ServiceTicketValidator.ValidateAsync(ticket, service, Request.CallCancelled)
+            var proxyCallbackUrl = Options.ProxyCallbackPath.HasValue
+                ? BuildRedirectUri(Options.ProxyCallbackPath.Value)
+                : null;
+            if (proxyCallbackUrl != null && !proxyCallbackUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.WriteWarning(
+                    $"ProxyCallbackPath is configured but the resulting URL '{proxyCallbackUrl}' is not HTTPS; CAS requires pgtUrl to be HTTPS and will not issue a Proxy Granting Ticket to it.");
+            }
+
+            var principal = await Options.ServiceTicketValidator
+                .ValidateAsync(ticket, service, Request.CallCancelled, proxyCallbackUrl)
                 .ConfigureAwait(false);
 
             if (principal == null)

--- a/src/GSS.Authentication.CAS.Owin/CasAuthenticationOptions.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasAuthenticationOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net.Http;
+using GSS.Authentication.CAS.Proxy;
 using GSS.Authentication.CAS.Validation;
 using Microsoft.Owin;
 using Microsoft.Owin.Infrastructure;
@@ -95,6 +96,21 @@ namespace GSS.Authentication.CAS.Owin
         /// </summary>
         /// <remarks>This URI can be out of the application's domain. By default it points to the root.</remarks>
         public string SignedOutRedirectUri { get; set; } = "/";
+
+        /// <summary>
+        /// The request path within the application's base path where CAS will deliver a Proxy Granting Ticket
+        /// (<c>pgtId</c>/<c>pgtIou</c>) after successfully validating a service ticket for which a <c>pgtUrl</c> was
+        /// requested. Must be reachable over HTTPS by the CAS server. Leave unset (the default) to not request PGTs.
+        /// See CAS Protocol Specification §2.5.4/§3.3/§3.4.
+        /// </summary>
+        public PathString ProxyCallbackPath { get; set; }
+
+        /// <summary>
+        /// Correlates the PGTIOU returned in the validation response with the real Proxy Granting Ticket delivered
+        /// to <see cref="ProxyCallbackPath"/>. Defaults to an in-memory, single-process store; provide a
+        /// distributed implementation for multi-instance deployments.
+        /// </summary>
+        public IProxyGrantingTicketStore ProxyGrantingTicketStore { get; set; } = new InMemoryProxyGrantingTicketStore();
 
         /// <summary>
         /// Gets or sets the <see cref="IServiceTicketValidator"/> used to validate service ticket.

--- a/test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationMiddlewareTests.cs
+++ b/test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationMiddlewareTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Security.Claims;
+using GSS.Authentication.CAS.Proxy;
 using GSS.Authentication.CAS.Security;
 using GSS.Authentication.CAS.Validation;
 using Microsoft.AspNetCore.Authentication;
@@ -227,6 +228,64 @@ public class CasAuthenticationMiddlewareTests
         Assert.Equal(principal.GetPrincipalName(), bodyText);
         await ticketValidator
             .Received(1).ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ProxyCallback_WithPgtIdAndPgtIou_ShouldStoreInProxyGrantingTicketStore()
+    {
+        // Arrange
+        var store = new InMemoryProxyGrantingTicketStore();
+        using var host = CreateHost(options =>
+        {
+            options.CasServerUrlBase = CasServerUrlBase;
+            options.ProxyCallbackPath = "/proxyCallback";
+            options.ProxyGrantingTicketStore = store;
+        });
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync("/proxyCallback?pgtId=PGT-1-abc&pgtIou=PGTIOU-1-abc",
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("PGT-1-abc", await store.GetAsync("PGTIOU-1-abc", TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task SignInChallenge_WithProxyCallbackPathConfigured_ShouldRequestProxyGrantingTicket()
+    {
+        // Arrange
+        var ticketValidator = Substitute.For<IServiceTicketValidator>();
+        var ticket = Guid.NewGuid().ToString();
+        var principal = new CasPrincipal(new Assertion(Guid.NewGuid().ToString()), CasDefaults.AuthenticationType);
+        ticketValidator
+            .ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>(), Arg.Any<string>())
+            .Returns(Task.FromResult<ICasPrincipal?>(principal));
+        using var host = CreateHost(options =>
+        {
+            options.ServiceTicketValidator = ticketValidator;
+            options.CasServerUrlBase = CasServerUrlBase;
+            options.ProxyCallbackPath = "/proxyCallback";
+        });
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+        using var challengeResponse =
+            await client.GetAsync(CookieAuthenticationDefaults.LoginPath, TestContext.Current.CancellationToken);
+        var query = QueryHelpers.ParseQuery(challengeResponse.Headers.Location?.Query);
+        var validateUrl =
+            QueryHelpers.AddQueryString(query[Constants.Parameters.Service]!, Constants.Parameters.Ticket, ticket);
+
+        // Act
+        using var signInRequest = challengeResponse.GetRequestWithCookies(validateUrl);
+        await client.SendAsync(signInRequest, TestContext.Current.CancellationToken);
+
+        // Assert
+        await ticketValidator.Received(1).ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>(),
+            Arg.Is<string>(url => url != null && url.EndsWith("/proxyCallback", StringComparison.Ordinal)));
     }
 
     [Fact]

--- a/test/GSS.Authentication.CAS.Core.Tests/Cas20ServiceTicketValidationTests.cs
+++ b/test/GSS.Authentication.CAS.Core.Tests/Cas20ServiceTicketValidationTests.cs
@@ -18,6 +18,7 @@ public class Cas20ServiceTicketValidationTests
     {
         // Arrange
         var ticket = Guid.NewGuid().ToString();
+        var proxyGrantingTicketIou = $"PGTIOU-{Guid.NewGuid()}";
         var requestUrl =
             $"{_options.CasServerUrlBase}/serviceValidate?ticket={ticket}&service={Uri.EscapeDataString(ServiceUrl)}";
         var mockHttp = new MockHttpMessageHandler();
@@ -26,7 +27,7 @@ public class Cas20ServiceTicketValidationTests
             .Respond(new StringContent(@$"<cas:serviceResponse xmlns:cas=""http://www.yale.edu/tp/cas"">
     <cas:authenticationSuccess>
         <cas:user>username</cas:user>
-        <cas:proxyGrantingTicket>{Guid.NewGuid()}</cas:proxyGrantingTicket>
+        <cas:proxyGrantingTicket>{proxyGrantingTicketIou}</cas:proxyGrantingTicket>
     </cas:authenticationSuccess>
 </cas:serviceResponse>", Encoding.UTF8, "application/xml"));
         var validator = new Cas20ServiceTicketValidator(_options, new HttpClient(mockHttp));
@@ -39,6 +40,34 @@ public class Cas20ServiceTicketValidationTests
         Assert.NotNull(principal.Assertion);
         Assert.Equal(principal.GetPrincipalName(), principal.Assertion.PrincipalName);
         Assert.Empty(principal.Assertion.Attributes);
+        Assert.Equal(proxyGrantingTicketIou, principal.Assertion.ProxyGrantingTicketIou);
+        Assert.Empty(principal.Assertion.Proxies);
+        mockHttp.VerifyNoOutstandingRequest();
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task ValidateServiceTicketWithProxyCallbackUrl_ShouldAppendPgtUrlParameter()
+    {
+        // Arrange
+        var ticket = Guid.NewGuid().ToString();
+        const string proxyCallbackUrl = "https://dev.example.test/proxyCallback";
+        var requestUrl =
+            $"{_options.CasServerUrlBase}/serviceValidate?ticket={ticket}&service={Uri.EscapeDataString(ServiceUrl)}&pgtUrl={Uri.EscapeDataString(proxyCallbackUrl)}";
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.Expect(HttpMethod.Get, requestUrl)
+            .Respond(new StringContent(@"<cas:serviceResponse xmlns:cas=""http://www.yale.edu/tp/cas"">
+    <cas:authenticationSuccess>
+        <cas:user>username</cas:user>
+    </cas:authenticationSuccess>
+</cas:serviceResponse>", Encoding.UTF8, "application/xml"));
+        var validator = new Cas20ServiceTicketValidator(_options, new HttpClient(mockHttp));
+
+        // Act
+        var principal = await validator.ValidateAsync(ticket, ServiceUrl, CancellationToken.None, proxyCallbackUrl);
+
+        // Assert
+        Assert.NotNull(principal);
         mockHttp.VerifyNoOutstandingRequest();
         mockHttp.VerifyNoOutstandingExpectation();
     }

--- a/test/GSS.Authentication.CAS.Core.Tests/Cas30ServiceTicketValidationTests.cs
+++ b/test/GSS.Authentication.CAS.Core.Tests/Cas30ServiceTicketValidationTests.cs
@@ -18,6 +18,7 @@ public class Cas30ServiceTicketValidationTests
     {
         // Arrange
         var ticket = Guid.NewGuid().ToString();
+        var proxyGrantingTicketIou = $"PGTIOU-{Guid.NewGuid()}";
         var requestUrl =
             $"{_options.CasServerUrlBase}/p3/serviceValidate?ticket={ticket}&service={Uri.EscapeDataString(ServiceUrl)}";
         var mockHttp = new MockHttpMessageHandler();
@@ -33,7 +34,7 @@ public class Cas30ServiceTicketValidationTests
             <cas:affiliation>staff</cas:affiliation>
             <cas:affiliation>faculty</cas:affiliation>
         </cas:attributes>
-        <cas:proxyGrantingTicket>{Guid.NewGuid()}</cas:proxyGrantingTicket>
+        <cas:proxyGrantingTicket>{proxyGrantingTicketIou}</cas:proxyGrantingTicket>
     </cas:authenticationSuccess>
 </cas:serviceResponse>", Encoding.UTF8, "application/xml"));
         var validator = new Cas30ServiceTicketValidator(_options, new HttpClient(mockHttp));
@@ -46,6 +47,7 @@ public class Cas30ServiceTicketValidationTests
         Assert.NotNull(principal.Assertion);
         Assert.Equal(principal.GetPrincipalName(), principal.Assertion.PrincipalName);
         Assert.NotEmpty(principal.Assertion.Attributes);
+        Assert.Equal(proxyGrantingTicketIou, principal.Assertion.ProxyGrantingTicketIou);
         mockHttp.VerifyNoOutstandingRequest();
         mockHttp.VerifyNoOutstandingExpectation();
     }

--- a/test/GSS.Authentication.CAS.Core.Tests/CasProxyTicketProviderTests.cs
+++ b/test/GSS.Authentication.CAS.Core.Tests/CasProxyTicketProviderTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Security.Authentication;
+using System.Text;
+using GSS.Authentication.CAS.Proxy;
+using RichardSzalay.MockHttp;
+using Xunit;
+
+namespace GSS.Authentication.CAS.Core.Tests;
+
+public class CasProxyTicketProviderTests
+{
+    private readonly ICasOptions _options = new CasOptions { CasServerUrlBase = "https://cas.example.org/cas" };
+
+    private const string ProxyGrantingTicket = "PGT-1-abc123";
+    private const string TargetService = "https://backend.example.test";
+
+    [Fact]
+    public async Task GetProxyTicketAsync_WithSuccessXmlResponse_ShouldReturnProxyTicket()
+    {
+        // Arrange
+        var requestUrl =
+            $"{_options.CasServerUrlBase}/proxy?pgt={ProxyGrantingTicket}&targetService={Uri.EscapeDataString(TargetService)}";
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.Expect(HttpMethod.Get, requestUrl)
+            .Respond(new StringContent(@"<cas:serviceResponse xmlns:cas=""http://www.yale.edu/tp/cas"">
+    <cas:proxySuccess>
+        <cas:proxyTicket>PT-1-abc123</cas:proxyTicket>
+    </cas:proxySuccess>
+</cas:serviceResponse>", Encoding.UTF8, "application/xml"));
+        var provider = new CasProxyTicketProvider(_options, new HttpClient(mockHttp));
+
+        // Act
+        var proxyTicket =
+            await provider.GetProxyTicketAsync(ProxyGrantingTicket, TargetService,
+                TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal("PT-1-abc123", proxyTicket);
+        mockHttp.VerifyNoOutstandingRequest();
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task GetProxyTicketAsync_WithFailXmlResponse_ShouldThrowsAuthenticationException()
+    {
+        // Arrange
+        var requestUrl =
+            $"{_options.CasServerUrlBase}/proxy?pgt={ProxyGrantingTicket}&targetService={Uri.EscapeDataString(TargetService)}";
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.Expect(HttpMethod.Get, requestUrl)
+            .Respond(new StringContent(@"<cas:serviceResponse xmlns:cas=""http://www.yale.edu/tp/cas"">
+    <cas:proxyFailure code=""INVALID_TICKET"">
+        Ticket PGT-1-abc123 not recognized
+    </cas:proxyFailure>
+</cas:serviceResponse>", Encoding.UTF8, "application/xml"));
+        var provider = new CasProxyTicketProvider(_options, new HttpClient(mockHttp));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<AuthenticationException>(() =>
+            provider.GetProxyTicketAsync(ProxyGrantingTicket, TargetService,
+                TestContext.Current.CancellationToken));
+        mockHttp.VerifyNoOutstandingRequest();
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task GetProxyTicketAsync_WithBadResponse_ShouldThrowsHttpRequestException()
+    {
+        // Arrange
+        var requestUrl =
+            $"{_options.CasServerUrlBase}/proxy?pgt={ProxyGrantingTicket}&targetService={Uri.EscapeDataString(TargetService)}";
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.Expect(HttpMethod.Get, requestUrl)
+            .Respond(HttpStatusCode.BadRequest);
+        var provider = new CasProxyTicketProvider(_options, new HttpClient(mockHttp));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            provider.GetProxyTicketAsync(ProxyGrantingTicket, TargetService,
+                TestContext.Current.CancellationToken));
+        mockHttp.VerifyNoOutstandingRequest();
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+}

--- a/test/GSS.Authentication.CAS.Core.Tests/InMemoryProxyGrantingTicketStoreTests.cs
+++ b/test/GSS.Authentication.CAS.Core.Tests/InMemoryProxyGrantingTicketStoreTests.cs
@@ -1,0 +1,52 @@
+using GSS.Authentication.CAS.Proxy;
+using Xunit;
+
+namespace GSS.Authentication.CAS.Core.Tests;
+
+public class InMemoryProxyGrantingTicketStoreTests
+{
+    [Fact]
+    public async Task StoreThenGet_ShouldReturnStoredProxyGrantingTicket()
+    {
+        // Arrange
+        var store = new InMemoryProxyGrantingTicketStore();
+        const string iou = "PGTIOU-1-abc123";
+        const string pgt = "PGT-1-abc123";
+
+        // Act
+        await store.StoreAsync(iou, pgt, TestContext.Current.CancellationToken);
+        var result = await store.GetAsync(iou, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(pgt, result);
+    }
+
+    [Fact]
+    public async Task Get_WithUnknownIou_ShouldReturnNull()
+    {
+        // Arrange
+        var store = new InMemoryProxyGrantingTicketStore();
+
+        // Act
+        var result = await store.GetAsync("PGTIOU-unknown", TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task Remove_ShouldMakeSubsequentGetReturnNull()
+    {
+        // Arrange
+        var store = new InMemoryProxyGrantingTicketStore();
+        const string iou = "PGTIOU-1-abc123";
+        await store.StoreAsync(iou, "PGT-1-abc123", TestContext.Current.CancellationToken);
+
+        // Act
+        await store.RemoveAsync(iou, TestContext.Current.CancellationToken);
+        var result = await store.GetAsync(iou, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Null(result);
+    }
+}

--- a/test/GSS.Authentication.CAS.Core.Tests/ProxyTicketValidationTests.cs
+++ b/test/GSS.Authentication.CAS.Core.Tests/ProxyTicketValidationTests.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using GSS.Authentication.CAS.Validation;
+using RichardSzalay.MockHttp;
+using Xunit;
+
+namespace GSS.Authentication.CAS.Core.Tests;
+
+public class ProxyTicketValidationTests
+{
+    private readonly ICasOptions _options = new CasOptions { CasServerUrlBase = "https://cas.example.org/cas" };
+
+    private const string ServiceUrl = "https://dev.example.test";
+
+    [Fact]
+    public async Task Cas20ProxyTicketValidator_WithProxiesInResponse_ShouldReturnPrincipalWithProxies()
+    {
+        // Arrange
+        var ticket = Guid.NewGuid().ToString();
+        var requestUrl =
+            $"{_options.CasServerUrlBase}/proxyValidate?ticket={ticket}&service={Uri.EscapeDataString(ServiceUrl)}";
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.Expect(HttpMethod.Get, requestUrl)
+            .Respond(new StringContent(@"<cas:serviceResponse xmlns:cas=""http://www.yale.edu/tp/cas"">
+    <cas:authenticationSuccess>
+        <cas:user>username</cas:user>
+        <cas:proxies>
+            <cas:proxy>https://proxy2.example.org/pgtUrl</cas:proxy>
+            <cas:proxy>https://proxy1.example.org/pgtUrl</cas:proxy>
+        </cas:proxies>
+    </cas:authenticationSuccess>
+</cas:serviceResponse>", Encoding.UTF8, "application/xml"));
+        var validator = new Cas20ProxyTicketValidator(_options, new HttpClient(mockHttp));
+
+        // Act
+        var principal = await validator.ValidateAsync(ticket, ServiceUrl, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(principal);
+        Assert.Equal(["https://proxy2.example.org/pgtUrl", "https://proxy1.example.org/pgtUrl"],
+            principal.Assertion.Proxies);
+        mockHttp.VerifyNoOutstandingRequest();
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task Cas30ProxyTicketValidator_WithProxiesInResponse_ShouldReturnPrincipalWithProxies()
+    {
+        // Arrange
+        var ticket = Guid.NewGuid().ToString();
+        var requestUrl =
+            $"{_options.CasServerUrlBase}/p3/proxyValidate?ticket={ticket}&service={Uri.EscapeDataString(ServiceUrl)}";
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.Expect(HttpMethod.Get, requestUrl)
+            .Respond(new StringContent(@"<cas:serviceResponse xmlns:cas=""http://www.yale.edu/tp/cas"">
+    <cas:authenticationSuccess>
+        <cas:user>username</cas:user>
+        <cas:proxies>
+            <cas:proxy>https://proxy1.example.org/pgtUrl</cas:proxy>
+        </cas:proxies>
+    </cas:authenticationSuccess>
+</cas:serviceResponse>", Encoding.UTF8, "application/xml"));
+        var validator = new Cas30ProxyTicketValidator(_options, new HttpClient(mockHttp));
+
+        // Act
+        var principal = await validator.ValidateAsync(ticket, ServiceUrl, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(principal);
+        Assert.Equal(["https://proxy1.example.org/pgtUrl"], principal.Assertion.Proxies);
+        mockHttp.VerifyNoOutstandingRequest();
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+}


### PR DESCRIPTION
## Summary
- Parse `cas:proxyGrantingTicket`/`cas:proxies` (previously silently ignored) from CAS 2.0/3.0 validation responses.
- Add `Cas20ProxyTicketValidator`/`Cas30ProxyTicketValidator` for `/proxyValidate`/`/p3/proxyValidate`.
- Add `IProxyGrantingTicketStore`/`InMemoryProxyGrantingTicketStore` + `IProxyTicketProvider`/`CasProxyTicketProvider` to correlate a PGTIOU with the real PGT delivered to a `pgtUrl` callback, and exchange it for a Proxy Ticket via `/proxy`.
- Wire a `ProxyCallbackPath`/`ProxyGrantingTicketStore` option into both ASP.NET Core and OWIN: when configured, ticket validation requests a `pgtUrl`, and a new request handler receives/stores the resulting `pgtId`/`pgtIou`. Behavior is unchanged when uncustomized.
- `IServiceTicketValidator.ValidateAsync` gained a new optional trailing `proxyCallbackUrl` parameter (existing 3-positional-arg call sites remain source-compatible).

Part of #1035. Closes #1031

## Deliberately out of scope
- No certificate validation in the callback receiver — per CAS Protocol Specification §2.5.4/§3.3, the PKIX check on the `pgtUrl` endpoint's certificate is performed by the CAS server before it calls back, not by the receiving client.
- No Keycloak-backed E2E coverage or sample app changes. The ASP.NET Core/OWIN TestServer integration tests already exercise the full request pipeline (callback endpoint wiring, `pgtUrl` propagation) end-to-end against a substituted validator; standing up a real proxy-target backend service in the E2E/devcontainer setup felt disproportionate to add in this PR. Can be revisited if real-world usage surfaces gaps the mocked tests don't catch.

## Test plan
- [x] `dotnet build` (0 warnings, all TFMs: netstandard2.0, netcoreapp3.1, net8.0, net10.0, net462)
- [x] `dotnet test --filter "FullyQualifiedName!~E2E"` (282 passed)
- [x] OWIN package + tests build clean (`dotnet build owin/GSS.Authentication.CAS.Owin.Tests`); local Mono install is currently unavailable on this machine, so OWIN test *execution* relies on CI (see `docs/lessons-learned.md`)
- [x] `/code-review` (Standards + Spec axes) — findings addressed: extracted a shared `GetBaseUri()` helper to remove duplicated base-URL normalization, added missing XML doc comments on the new `Proxy` namespace's public API, added an HTTPS guard/log warning when `ProxyCallbackPath` resolves to a non-HTTPS URL