### PR TITLE
feat: support format=JSON responses for CAS 2.0/3.0 ticket validation

### DIFF
--- a/src/GSS.Authentication.CAS.Core/GSS.Authentication.CAS.Core.csproj
+++ b/src/GSS.Authentication.CAS.Core/GSS.Authentication.CAS.Core.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Extensions.Primitives" />
+    <PackageReference Include="System.Text.Json" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' ">

--- a/src/GSS.Authentication.CAS.Core/Validation/Cas10ServiceTicketValidator.cs
+++ b/src/GSS.Authentication.CAS.Core/Validation/Cas10ServiceTicketValidator.cs
@@ -13,7 +13,7 @@ namespace GSS.Authentication.CAS.Validation
         {
         }
 
-        protected override ICasPrincipal? BuildPrincipal(string responseBody)
+        protected override ICasPrincipal? BuildPrincipal(string responseBody, string? contentType)
         {
             var responseParts = responseBody.Split('\n');
             if (responseParts.Length < 2 || responseParts[0] != "yes")

--- a/src/GSS.Authentication.CAS.Core/Validation/Cas20ServiceTicketValidator.cs
+++ b/src/GSS.Authentication.CAS.Core/Validation/Cas20ServiceTicketValidator.cs
@@ -1,7 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Authentication;
+using System.Text.Json;
 using System.Xml.Linq;
 using GSS.Authentication.CAS.Security;
 using Microsoft.Extensions.Primitives;
@@ -20,6 +22,17 @@ namespace GSS.Authentication.CAS.Validation
         private static readonly XName _proxies = _namespace + "proxies";
         private static readonly XName _proxy = _namespace + "proxy";
 
+        private const string JsonMediaType = "application/json";
+        private const string JsonServiceResponse = "serviceResponse";
+        private const string JsonAuthenticationSuccess = "authenticationSuccess";
+        private const string JsonAuthenticationFailure = "authenticationFailure";
+        private const string JsonUser = "user";
+        private const string JsonAttributes = "attributes";
+        private const string JsonProxyGrantingTicket = "proxyGrantingTicket";
+        private const string JsonProxies = "proxies";
+        private const string JsonFailureCode = "code";
+        private const string JsonFailureDescription = "description";
+
         public Cas20ServiceTicketValidator(
             ICasOptions options,
             HttpClient? httpClient = null)
@@ -35,8 +48,13 @@ namespace GSS.Authentication.CAS.Validation
         {
         }
 
-        protected override ICasPrincipal? BuildPrincipal(string responseBody)
+        protected override ICasPrincipal? BuildPrincipal(string responseBody, string? contentType)
         {
+            if (string.Equals(contentType, JsonMediaType, StringComparison.OrdinalIgnoreCase))
+            {
+                return BuildPrincipalFromJson(responseBody);
+            }
+
             var doc = XElement.Parse(responseBody);
             /* On ticket validation failure:
             <cas:serviceResponse xmlns:cas="http://www.yale.edu/tp/cas">
@@ -97,6 +115,68 @@ namespace GSS.Authentication.CAS.Validation
             var proxies = successElement.Element(_proxies)?.Elements(_proxy).Select(e => e.Value).ToList();
 
             var assertion = new Assertion(principalName, attributes, proxyGrantingTicketIou, proxies);
+            return new CasPrincipal(assertion, Options.AuthenticationType);
+        }
+
+        /// <summary>
+        /// Parses a CAS 3.0 <c>format=JSON</c> response, mirroring the same <c>user</c>/<c>attributes</c>/
+        /// failure-code structure as the XML response.
+        /// </summary>
+        /// <remarks>
+        /// On failure:
+        /// <code>{"serviceResponse":{"authenticationFailure":{"code":"INVALID_TICKET","description":"..."}}}</code>
+        /// On success:
+        /// <code>{"serviceResponse":{"authenticationSuccess":{"user":"username","attributes":{"firstname":["John"],"affiliation":["staff","faculty"]}}}}</code>
+        /// </remarks>
+        private ICasPrincipal? BuildPrincipalFromJson(string responseBody)
+        {
+            using var doc = JsonDocument.Parse(responseBody);
+            if (!doc.RootElement.TryGetProperty(JsonServiceResponse, out var serviceResponse))
+                return null;
+
+            if (serviceResponse.TryGetProperty(JsonAuthenticationFailure, out var failureElement))
+            {
+                var description = failureElement.TryGetProperty(JsonFailureDescription, out var descriptionElement)
+                    ? descriptionElement.GetString()
+                    : failureElement.TryGetProperty(JsonFailureCode, out var codeElement)
+                        ? codeElement.GetString()
+                        : null;
+                throw new AuthenticationException(description ?? "Ticket validation failed");
+            }
+
+            if (!serviceResponse.TryGetProperty(JsonAuthenticationSuccess, out var successElement))
+                return null;
+
+            var principalName = successElement.TryGetProperty(JsonUser, out var userElement)
+                ? userElement.GetString()
+                : null;
+            if (string.IsNullOrWhiteSpace(principalName))
+                return null;
+
+            var attributes = new Dictionary<string, StringValues>();
+            if (successElement.TryGetProperty(JsonAttributes, out var attributesElement))
+            {
+                foreach (var attribute in attributesElement.EnumerateObject())
+                {
+                    var values = attribute.Value.ValueKind == JsonValueKind.Array
+                        ? attribute.Value.EnumerateArray().Select(v => v.GetString() ?? string.Empty).ToArray()
+                        : [attribute.Value.GetString() ?? string.Empty];
+                    attributes[attribute.Name] = new StringValues(values);
+                }
+            }
+
+            var proxyGrantingTicketIou = successElement.TryGetProperty(JsonProxyGrantingTicket, out var pgtElement)
+                ? pgtElement.GetString()
+                : null;
+            List<string>? proxies = null;
+            if (successElement.TryGetProperty(JsonProxies, out var proxiesElement) &&
+                proxiesElement.ValueKind == JsonValueKind.Array)
+            {
+                proxies = proxiesElement.EnumerateArray().Select(p => p.GetString() ?? string.Empty).ToList();
+            }
+
+            // IsNullOrWhiteSpace isn't annotated [NotNullWhen(false)] on the netstandard2.0 reference assembly.
+            var assertion = new Assertion(principalName!, attributes, proxyGrantingTicketIou, proxies);
             return new CasPrincipal(assertion, Options.AuthenticationType);
         }
     }

--- a/src/GSS.Authentication.CAS.Core/Validation/CasServiceTicketValidator.cs
+++ b/src/GSS.Authentication.CAS.Core/Validation/CasServiceTicketValidator.cs
@@ -46,9 +46,19 @@ namespace GSS.Authentication.CAS.Validation
             }
 
             var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            return BuildPrincipal(responseBody);
+            return BuildPrincipal(responseBody, response.Content.Headers.ContentType?.MediaType);
         }
 
-        protected abstract ICasPrincipal? BuildPrincipal(string responseBody);
+        /// <summary>
+        /// Parses the validation response into a principal, or <see langword="null"/> if the response indicates
+        /// the ticket didn't resolve to an authenticated user.
+        /// </summary>
+        /// <param name="responseBody">The raw response body from the CAS server.</param>
+        /// <param name="contentType">
+        /// The response's media type (e.g. <c>application/xml</c>, <c>application/json</c>), used by validators
+        /// that support the CAS 3.0 <c>format</c> parameter to pick the right parser for whatever the server
+        /// actually returned.
+        /// </param>
+        protected abstract ICasPrincipal? BuildPrincipal(string responseBody, string? contentType);
     }
 }

--- a/test/GSS.Authentication.CAS.Core.Tests/Cas20ServiceTicketValidationTests.cs
+++ b/test/GSS.Authentication.CAS.Core.Tests/Cas20ServiceTicketValidationTests.cs
@@ -73,6 +73,82 @@ public class Cas20ServiceTicketValidationTests
     }
 
     [Fact]
+    public async Task ValidateServiceTicketWithSuccessJsonResponse_ShouldReturnPrincipal()
+    {
+        // Arrange
+        var ticket = Guid.NewGuid().ToString();
+        var requestUrl =
+            $"{_options.CasServerUrlBase}/serviceValidate?ticket={ticket}&service={Uri.EscapeDataString(ServiceUrl)}";
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.Expect(HttpMethod.Get, requestUrl)
+            .Respond(new StringContent(
+                """
+                {"serviceResponse":{"authenticationSuccess":{"user":"username","attributes":{"firstname":["John"],"affiliation":["staff","faculty"]}}}}
+                """, Encoding.UTF8, "application/json"));
+        var validator = new Cas20ServiceTicketValidator(_options, new HttpClient(mockHttp));
+
+        // Act
+        var principal = await validator.ValidateAsync(ticket, ServiceUrl, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(principal);
+        Assert.Equal("username", principal.Assertion.PrincipalName);
+        Assert.Equal("John", principal.Assertion.Attributes["firstname"]);
+        Assert.Equal(["staff", "faculty"], principal.Assertion.Attributes["affiliation"].ToArray());
+        mockHttp.VerifyNoOutstandingRequest();
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task ValidateServiceTicketWithSuccessJsonResponse_ShouldReturnProxyGrantingTicketIouAndProxies()
+    {
+        // Arrange
+        var ticket = Guid.NewGuid().ToString();
+        var requestUrl =
+            $"{_options.CasServerUrlBase}/serviceValidate?ticket={ticket}&service={Uri.EscapeDataString(ServiceUrl)}";
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.Expect(HttpMethod.Get, requestUrl)
+            .Respond(new StringContent(
+                """
+                {"serviceResponse":{"authenticationSuccess":{"user":"username","proxyGrantingTicket":"PGTIOU-1-abc","proxies":["https://proxy1.example.org/pgtUrl"]}}}
+                """, Encoding.UTF8, "application/json"));
+        var validator = new Cas20ServiceTicketValidator(_options, new HttpClient(mockHttp));
+
+        // Act
+        var principal = await validator.ValidateAsync(ticket, ServiceUrl, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(principal);
+        Assert.Equal("PGTIOU-1-abc", principal.Assertion.ProxyGrantingTicketIou);
+        Assert.Equal(["https://proxy1.example.org/pgtUrl"], principal.Assertion.Proxies);
+        mockHttp.VerifyNoOutstandingRequest();
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
+    public async Task ValidateServiceTicketWithFailJsonResponse_ShouldThrowsAuthenticationException()
+    {
+        // Arrange
+        var ticket = Guid.NewGuid().ToString();
+        var requestUrl =
+            $"{_options.CasServerUrlBase}/serviceValidate?ticket={ticket}&service={Uri.EscapeDataString(ServiceUrl)}";
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.Expect(HttpMethod.Get, requestUrl)
+            .Respond(new StringContent(
+                """
+                {"serviceResponse":{"authenticationFailure":{"code":"INVALID_TICKET","description":"Ticket not recognized"}}}
+                """, Encoding.UTF8, "application/json"));
+        var validator = new Cas20ServiceTicketValidator(_options, new HttpClient(mockHttp));
+
+        // Act & Assert
+        await Assert
+            .ThrowsAsync<AuthenticationException>(() =>
+                validator.ValidateAsync(ticket, ServiceUrl, TestContext.Current.CancellationToken));
+        mockHttp.VerifyNoOutstandingRequest();
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
     public async Task ValidateServiceTicketWithFailXmlResponse_ShouldThrowsAuthenticationException()
     {
         // Arrange

--- a/test/GSS.Authentication.CAS.Core.Tests/Cas30ServiceTicketValidationTests.cs
+++ b/test/GSS.Authentication.CAS.Core.Tests/Cas30ServiceTicketValidationTests.cs
@@ -53,6 +53,32 @@ public class Cas30ServiceTicketValidationTests
     }
 
     [Fact]
+    public async Task ValidateServiceTicketWithSuccessJsonResponse_ShouldReturnPrincipal()
+    {
+        // Arrange
+        var ticket = Guid.NewGuid().ToString();
+        var requestUrl =
+            $"{_options.CasServerUrlBase}/p3/serviceValidate?ticket={ticket}&service={Uri.EscapeDataString(ServiceUrl)}";
+        var mockHttp = new MockHttpMessageHandler();
+        mockHttp.Expect(HttpMethod.Get, requestUrl)
+            .Respond(new StringContent(
+                """
+                {"serviceResponse":{"authenticationSuccess":{"user":"username","attributes":{"firstname":["John"]}}}}
+                """, Encoding.UTF8, "application/json"));
+        var validator = new Cas30ServiceTicketValidator(_options, new HttpClient(mockHttp));
+
+        // Act
+        var principal = await validator.ValidateAsync(ticket, ServiceUrl, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(principal);
+        Assert.Equal("username", principal.Assertion.PrincipalName);
+        Assert.Equal("John", principal.Assertion.Attributes["firstname"]);
+        mockHttp.VerifyNoOutstandingRequest();
+        mockHttp.VerifyNoOutstandingExpectation();
+    }
+
+    [Fact]
     public async Task ValidateServiceTicketWithUnsupportedCasServer_ShouldThrowsHttpRequestException()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- `Cas20ServiceTicketValidator`/`Cas30ServiceTicketValidator` (and the `Cas20ProxyTicketValidator`/`Cas30ProxyTicketValidator` from #1031, which inherit the same parsing) always parsed responses as XML, throwing if a CAS server returned `format=JSON` instead.
- Detect JSON via the response `Content-Type` and parse it, mirroring the same `user`/`attributes`/failure-code/`proxyGrantingTicket`/`proxies` structure the XML path already extracts (including parity with #1031's proxy fields).
- The client doesn't request a specific format (no `format=` query param sent); it just parses whichever format the server actually returned, per the abstract `BuildPrincipal(responseBody, contentType)` signature change plumbed from `response.Content.Headers.ContentType`.

Part of #1035. Closes #1032

## Test plan
- [x] `dotnet build` (0 warnings, all TFMs)
- [x] `dotnet test --filter "FullyQualifiedName!~E2E"` (290 passed, includes new JSON success/failure/proxy-fields tests for both Cas20 and Cas30 validators)
- [x] OWIN package + tests build clean
- [x] `/code-review` (Standards + Spec axes) — findings addressed: removed a `KeyNotFoundException` footgun (`GetProperty` → `TryGetProperty` for the root `serviceResponse` object), added a missing `<summary>` doc on the newly-changed abstract `BuildPrincipal` method, extracted JSON property-name string literals into named constants (mirroring the XML path's `XName` fields), and documented why the `!` on `principalName` is needed (netstandard2.0's `IsNullOrWhiteSpace` isn't `[NotNullWhen(false)]`-annotated there). One noted-but-accepted smell: the XML and JSON parsing methods necessarily duplicate the same extraction shape against two different parser APIs — not judged worth abstracting away for two call sites.