### PR TITLE
feat: add renew/gateway/method/locale options for the CAS login redirect

### DIFF
--- a/owin/GSS.Authentication.CAS.Owin.Tests/CasAuthenticationMiddlewareTests.cs
+++ b/owin/GSS.Authentication.CAS.Owin.Tests/CasAuthenticationMiddlewareTests.cs
@@ -527,6 +527,71 @@ namespace GSS.Authentication.CAS.Owin.Tests
         }
 
         [Fact]
+        public async Task SignInChallenge_WithRenewGatewayMethodLocale_ShouldAppendQueryParameters()
+        {
+            // Arrange
+            using var server = CreateServer(options =>
+            {
+                options.CasServerUrlBase = CasServerUrlBase;
+                options.Renew = true;
+                options.Method = "POST";
+                options.Locale = "zh_TW";
+            });
+
+            // Act
+            using var response = await server.HttpClient.GetAsync("/challenge", TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+            var query = QueryHelpers.ParseQuery(response.Headers.Location.Query);
+            Assert.Equal("true", query[Constants.Parameters.Renew]);
+            Assert.Equal("POST", query[Constants.Parameters.Method]);
+            Assert.Equal("zh_TW", query[Constants.Parameters.Locale]);
+            Assert.False(query.ContainsKey(Constants.Parameters.Gateway));
+        }
+
+        [Fact]
+        public async Task SignInChallenge_WithGateway_ShouldAppendGatewayQueryParameter()
+        {
+            // Arrange
+            using var server = CreateServer(options =>
+            {
+                options.CasServerUrlBase = CasServerUrlBase;
+                options.Gateway = true;
+            });
+
+            // Act
+            using var response = await server.HttpClient.GetAsync("/challenge", TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.Found, response.StatusCode);
+            var query = QueryHelpers.ParseQuery(response.Headers.Location.Query);
+            Assert.Equal("true", query[Constants.Parameters.Gateway]);
+            Assert.False(query.ContainsKey(Constants.Parameters.Renew));
+        }
+
+        [Fact]
+        public async Task SignInChallenge_WithRenewAndGateway_ShouldThrows()
+        {
+            // Arrange
+            using var server = CreateServer(options =>
+            {
+                options.CasServerUrlBase = CasServerUrlBase;
+                options.Renew = true;
+                options.Gateway = true;
+            });
+
+            // Act
+            var exception = await Record.ExceptionAsync(() =>
+                server.HttpClient.GetAsync("/challenge", TestContext.Current.CancellationToken));
+
+            // Assert
+            // Katana's OWIN pipeline may or may not wrap this exception before it reaches HttpClient, so only
+            // assert that setting both Renew and Gateway fails the request rather than pinning the exact message.
+            Assert.NotNull(exception);
+        }
+
+        [Fact]
         public async Task SignInChallenge_WithPlainProvider_ShouldRedirectToCasLoginEndpointUnchanged()
         {
             // Arrange

--- a/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs
@@ -166,6 +166,25 @@ public class CasAuthenticationHandler : RemoteAuthenticationHandler<CasAuthentic
             $"{Options.CasServerUrlBase.TrimEnd('/')}{Constants.Paths.Login}",
             Constants.Parameters.Service, callbackUri);
 
+        if (Options.Renew)
+        {
+            redirectUri = QueryHelpers.AddQueryString(redirectUri, Constants.Parameters.Renew, "true");
+        }
+        else if (Options.Gateway)
+        {
+            redirectUri = QueryHelpers.AddQueryString(redirectUri, Constants.Parameters.Gateway, "true");
+        }
+
+        if (!string.IsNullOrEmpty(Options.Method))
+        {
+            redirectUri = QueryHelpers.AddQueryString(redirectUri, Constants.Parameters.Method, Options.Method);
+        }
+
+        if (!string.IsNullOrEmpty(Options.Locale))
+        {
+            redirectUri = QueryHelpers.AddQueryString(redirectUri, Constants.Parameters.Locale, Options.Locale);
+        }
+
         var redirectContext = new RedirectContext<CasAuthenticationOptions>(
             Context, Scheme, Options,
             properties, redirectUri);

--- a/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationOptions.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationOptions.cs
@@ -54,6 +54,32 @@ public class CasAuthenticationOptions : RemoteAuthenticationOptions, ICasOptions
     /// </summary>
     public IProxyGrantingTicketStore ProxyGrantingTicketStore { get; set; } = new InMemoryProxyGrantingTicketStore();
 
+    /// <summary>
+    /// Forces the user to re-authenticate with primary credentials, even if a valid SSO session already exists.
+    /// Mutually exclusive with <see cref="Gateway"/>. See CAS Protocol Specification §2.1.1.
+    /// </summary>
+    public bool Renew { get; set; }
+
+    /// <summary>
+    /// Attempts a transparent/silent authentication: CAS will not prompt for credentials, redirecting straight
+    /// back without a <c>ticket</c> if there's no existing SSO session. Mutually exclusive with <see cref="Renew"/>.
+    /// See CAS Protocol Specification §2.1.1.
+    /// </summary>
+    public bool Gateway { get; set; }
+
+    /// <summary>
+    /// The CAS 3.0 <c>method</c> parameter, controlling how CAS delivers the response to <c>service</c>
+    /// (e.g. <c>"POST"</c>, <c>"HEADER"</c>; the default, unset, is a <c>GET</c> redirect).
+    /// See CAS Protocol Specification §2.1.1.
+    /// </summary>
+    public string? Method { get; set; }
+
+    /// <summary>
+    /// A hint for the locale CAS should render its login page in. Not part of the core CAS protocol, but widely
+    /// supported by CAS server implementations.
+    /// </summary>
+    public string? Locale { get; set; }
+
     public new CasEvents Events
     {
         get => (CasEvents)base.Events;
@@ -67,6 +93,12 @@ public class CasAuthenticationOptions : RemoteAuthenticationOptions, ICasOptions
         if (string.IsNullOrWhiteSpace(CasServerUrlBase))
         {
             throw new ArgumentException($"The '{nameof(CasServerUrlBase)}' option must be provided.");
+        }
+
+        if (Renew && Gateway)
+        {
+            throw new ArgumentException(
+                $"'{nameof(Renew)}' and '{nameof(Gateway)}' cannot both be set, per the CAS protocol.");
         }
     }
 }

--- a/src/GSS.Authentication.CAS.Core/Constants.cs
+++ b/src/GSS.Authentication.CAS.Core/Constants.cs
@@ -11,6 +11,14 @@ namespace GSS.Authentication.CAS
             public const string ProxyGrantingTicketId = "pgtId";
 
             public const string ProxyGrantingTicketIou = "pgtIou";
+
+            public const string Renew = "renew";
+
+            public const string Gateway = "gateway";
+
+            public const string Method = "method";
+
+            public const string Locale = "locale";
         }
 
         public static class Paths

--- a/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasAuthenticationHandler.cs
@@ -281,6 +281,12 @@ namespace GSS.Authentication.CAS.Owin
 
             if (challenge != null)
             {
+                if (Options.Renew && Options.Gateway)
+                {
+                    throw new InvalidOperationException(
+                        $"'{nameof(Options.Renew)}' and '{nameof(Options.Gateway)}' cannot both be set, per the CAS protocol.");
+                }
+
                 var requestPrefix = Request.Scheme + Uri.SchemeDelimiter + Request.Host;
 
                 var state = challenge.Properties;
@@ -298,6 +304,29 @@ namespace GSS.Authentication.CAS.Owin
                 var authorizationEndpoint = QueryHelpers.AddQueryString(
                     $"{Options.CasServerUrlBase.TrimEnd('/')}{Constants.Paths.Login}",
                     Constants.Parameters.Service, returnTo);
+
+                if (Options.Renew)
+                {
+                    authorizationEndpoint =
+                        QueryHelpers.AddQueryString(authorizationEndpoint, Constants.Parameters.Renew, "true");
+                }
+                else if (Options.Gateway)
+                {
+                    authorizationEndpoint =
+                        QueryHelpers.AddQueryString(authorizationEndpoint, Constants.Parameters.Gateway, "true");
+                }
+
+                if (!string.IsNullOrEmpty(Options.Method))
+                {
+                    authorizationEndpoint =
+                        QueryHelpers.AddQueryString(authorizationEndpoint, Constants.Parameters.Method, Options.Method);
+                }
+
+                if (!string.IsNullOrEmpty(Options.Locale))
+                {
+                    authorizationEndpoint =
+                        QueryHelpers.AddQueryString(authorizationEndpoint, Constants.Parameters.Locale, Options.Locale);
+                }
 
                 var redirectContext = new CasRedirectContext(Context, null) { RedirectUri = authorizationEndpoint };
                 if (Options.Provider is CasAuthenticationProvider provider)

--- a/src/GSS.Authentication.CAS.Owin/CasAuthenticationOptions.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasAuthenticationOptions.cs
@@ -113,6 +113,32 @@ namespace GSS.Authentication.CAS.Owin
         public IProxyGrantingTicketStore ProxyGrantingTicketStore { get; set; } = new InMemoryProxyGrantingTicketStore();
 
         /// <summary>
+        /// Forces the user to re-authenticate with primary credentials, even if a valid SSO session already exists.
+        /// Mutually exclusive with <see cref="Gateway"/>. See CAS Protocol Specification §2.1.1.
+        /// </summary>
+        public bool Renew { get; set; }
+
+        /// <summary>
+        /// Attempts a transparent/silent authentication: CAS will not prompt for credentials, redirecting straight
+        /// back without a <c>ticket</c> if there's no existing SSO session. Mutually exclusive with <see cref="Renew"/>.
+        /// See CAS Protocol Specification §2.1.1.
+        /// </summary>
+        public bool Gateway { get; set; }
+
+        /// <summary>
+        /// The CAS 3.0 <c>method</c> parameter, controlling how CAS delivers the response to <c>service</c>
+        /// (e.g. <c>"POST"</c>, <c>"HEADER"</c>; the default, unset, is a <c>GET</c> redirect).
+        /// See CAS Protocol Specification §2.1.1.
+        /// </summary>
+        public string? Method { get; set; }
+
+        /// <summary>
+        /// A hint for the locale CAS should render its login page in. Not part of the core CAS protocol, but widely
+        /// supported by CAS server implementations.
+        /// </summary>
+        public string? Locale { get; set; }
+
+        /// <summary>
         /// Gets or sets the <see cref="IServiceTicketValidator"/> used to validate service ticket.
         /// Default is <see cref="Cas30ServiceTicketValidator"/>.
         /// </summary>

--- a/test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationMiddlewareTests.cs
+++ b/test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationMiddlewareTests.cs
@@ -103,6 +103,58 @@ public class CasAuthenticationMiddlewareTests
     }
 
     [Fact]
+    public async Task SignInChallenge_WithRenewGatewayMethodLocale_ShouldAppendQueryParameters()
+    {
+        // Arrange
+        using var host = CreateHost(options =>
+        {
+            options.CasServerUrlBase = CasServerUrlBase;
+            options.Renew = true;
+            options.Method = "POST";
+            options.Locale = "zh_TW";
+        });
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync(CookieAuthenticationDefaults.LoginPath,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        var query = QueryHelpers.ParseQuery(response.Headers.Location?.Query);
+        Assert.Equal("true", query[Constants.Parameters.Renew]);
+        Assert.Equal("POST", query[Constants.Parameters.Method]);
+        Assert.Equal("zh_TW", query[Constants.Parameters.Locale]);
+        Assert.False(query.ContainsKey(Constants.Parameters.Gateway));
+    }
+
+    [Fact]
+    public async Task SignInChallenge_WithGateway_ShouldAppendGatewayQueryParameter()
+    {
+        // Arrange
+        using var host = CreateHost(options =>
+        {
+            options.CasServerUrlBase = CasServerUrlBase;
+            options.Gateway = true;
+        });
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+
+        // Act
+        using var response = await client.GetAsync(CookieAuthenticationDefaults.LoginPath,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        var query = QueryHelpers.ParseQuery(response.Headers.Location?.Query);
+        Assert.Equal("true", query[Constants.Parameters.Gateway]);
+        Assert.False(query.ContainsKey(Constants.Parameters.Renew));
+    }
+
+    [Fact]
     public async Task SignInChallenge_WithoutTicketInCallbackQuery_ShouldThrows()
     {
         // Arrange

--- a/test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationOptionsTests.cs
+++ b/test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationOptionsTests.cs
@@ -154,6 +154,23 @@ public class CasAuthenticationOptionsTests
     }
 
     [Fact]
+    public void Validate_ShouldThrowArgumentException_WhenRenewAndGatewayAreBothSet()
+    {
+        // Arrange
+        var options = new CasAuthenticationOptions
+        {
+            CasServerUrlBase = "https://cas.example.com/cas",
+            Renew = true,
+            Gateway = true
+        };
+
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentException>(() => options.Validate());
+        Assert.Contains("Renew", exception.Message);
+        Assert.Contains("Gateway", exception.Message);
+    }
+
+    [Fact]
     public void Validate_ShouldNotThrow_WhenCasServerUrlBaseIsValid()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Add `Renew`, `Gateway`, `Method`, and `Locale` properties to `CasAuthenticationOptions` (ASP.NET Core and OWIN), appended to the login redirect URL alongside `service` when set.
- `renew`/`gateway` are mutually exclusive per the CAS protocol: ASP.NET Core rejects both being set via `Options.Validate()` (fails at options-configuration time, before requests); OWIN, which has no equivalent validation hook in this codebase, rejects it per-request at the top of `ApplyResponseChallengeAsync` instead.
- Previously the only way to add these parameters was manually rewriting the redirect URL inside the `OnRedirectToAuthorizationEndpoint`/`RedirectToIdentityProviderForSignIn` hook. Uncustomized behavior is unchanged.

Part of #1035. Closes #1033

## Test plan
- [x] `dotnet build` (0 warnings, all TFMs)
- [x] `dotnet test --filter "FullyQualifiedName!~E2E"` (296 passed, includes new tests for `Renew`/`Gateway`/`Method`/`Locale` query-string wiring and the mutual-exclusivity validation on both packages)
- [x] OWIN package + tests build clean
- [x] `/code-review` (Standards + Spec axes) — findings addressed: moved the OWIN `Renew`+`Gateway` mutual-exclusivity check to the very top of the challenge method so it fails before the anti-CSRF correlation cookie is generated. One noted-but-accepted smell: the ASP.NET Core and OWIN handlers duplicate the same query-append logic, consistent with existing pre-diff duplication between the two handlers (e.g. `service`).