### PR TITLE
fix: harden Single Sign-Out with origin checks, document invalidation timing

### DIFF
--- a/owin/GSS.Authentication.CAS.Owin.Tests/CasSingleLogoutIntegrationTests.cs
+++ b/owin/GSS.Authentication.CAS.Owin.Tests/CasSingleLogoutIntegrationTests.cs
@@ -1,0 +1,185 @@
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using GSS.Authentication.CAS.Security;
+using GSS.Authentication.CAS.Validation;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Microsoft.Owin.Security;
+using Microsoft.Owin.Security.Cookies;
+using Microsoft.Owin.Security.DataProtection;
+using Microsoft.Owin.Testing;
+using NSubstitute;
+using Owin;
+using Xunit;
+
+namespace GSS.Authentication.CAS.Owin.Tests
+{
+    /// <summary>
+    /// End-to-end proof of exactly when a back-channel CAS logout takes effect on an already-signed-in cookie
+    /// session, backed by <see cref="DistributedCacheIAuthenticationSessionStore"/> as the cookie
+    /// authentication's session store.
+    /// </summary>
+    public class CasSingleLogoutIntegrationTests
+    {
+        private const string CasServerUrlBase = "https://cas.example.org/cas";
+
+        [Fact]
+        public async Task SignedInSession_AfterBackChannelLogout_ShouldBeUnauthenticatedOnNextRequest()
+        {
+            // Arrange
+            var ticketValidator = Substitute.For<IServiceTicketValidator>();
+            var ticket = Guid.NewGuid().ToString();
+            var principal = new CasPrincipal(new Assertion(Guid.NewGuid().ToString()), CasDefaults.AuthenticationType);
+            ticketValidator
+                .ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<ICasPrincipal?>(principal));
+            var store = new DistributedCacheIAuthenticationSessionStore(
+                new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+                Options.Create(new DistributedCacheIAuthenticationSessionStoreOptions()));
+
+            using var server = TestServer.Create(app =>
+            {
+                app.SetDataProtectionProvider(new FakeDataProtectionProvider(new AesDataProtector("test")));
+                app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
+                app.UseCookieAuthentication(new CookieAuthenticationOptions
+                {
+                    LoginPath = CookieAuthenticationDefaults.LoginPath,
+                    LogoutPath = CookieAuthenticationDefaults.LogoutPath,
+                    SessionStore = store
+                });
+                app.UseCasAuthentication(new CasAuthenticationOptions
+                {
+                    ServiceTicketValidator = ticketValidator,
+                    CasServerUrlBase = CasServerUrlBase,
+                    SaveTokens = true
+                });
+                app.Map("/cas-logout", logoutApp => logoutApp.UseCasSingleLogout(store));
+                app.Use(async (context, _) =>
+                {
+                    if (context.Request.Path.Value == "/login")
+                    {
+                        context.Authentication.Challenge(new AuthenticationProperties { RedirectUri = "/" },
+                            CasDefaults.AuthenticationType);
+                        return;
+                    }
+
+                    var user = context.Authentication.User;
+                    context.Response.StatusCode =
+                        user?.Identities.Any(identity => identity.IsAuthenticated) == true ? 200 : 401;
+                    await Task.CompletedTask;
+                });
+            });
+
+            using var challengeResponse =
+                await server.HttpClient.GetAsync("/login", TestContext.Current.CancellationToken);
+            var query = QueryHelpers.ParseQuery(challengeResponse.Headers.Location.Query);
+            var validateUrl =
+                QueryHelpers.AddQueryString(query[Constants.Parameters.Service], Constants.Parameters.Ticket, ticket);
+            using var signInRequest = challengeResponse.GetRequestWithCookies(validateUrl);
+            using var signInResponse =
+                await server.HttpClient.SendAsync(signInRequest, TestContext.Current.CancellationToken);
+
+            using var authorizedRequest = signInResponse.GetRequestWithCookies("/");
+            using var authorizedResponse =
+                await server.HttpClient.SendAsync(authorizedRequest, TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, authorizedResponse.StatusCode);
+
+            // Act
+            using var logoutContent = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["logoutRequest"] =
+                    $@"<samlp:LogoutRequest xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol"" ID=""{Guid.NewGuid()}"" Version=""2.0"" IssueInstant=""{DateTime.UtcNow:o}"">
+    <saml:NameID xmlns:saml=""urn:oasis:names:tc:SAML:2.0:assertion"">@NOT_USED@</saml:NameID>
+    <samlp:SessionIndex>{ticket}</samlp:SessionIndex></samlp:LogoutRequest>"
+            });
+            using var logoutResponse =
+                await server.HttpClient.PostAsync("/cas-logout", logoutContent, TestContext.Current.CancellationToken);
+
+            // Assert: the very next request with the same (still unexpired) cookie is no longer authenticated —
+            // removing the session-store entry takes effect immediately, with no polling interval or caching delay.
+            using var postLogoutRequest = signInResponse.GetRequestWithCookies("/");
+            using var postLogoutResponse =
+                await server.HttpClient.SendAsync(postLogoutRequest, TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.Unauthorized, postLogoutResponse.StatusCode);
+        }
+
+        [Fact]
+        public async Task SignedInSession_WithoutSessionStoreWired_ShouldStayAuthenticatedAfterBackChannelLogout()
+        {
+            // Arrange
+            var ticketValidator = Substitute.For<IServiceTicketValidator>();
+            var ticket = Guid.NewGuid().ToString();
+            var principal = new CasPrincipal(new Assertion(Guid.NewGuid().ToString()), CasDefaults.AuthenticationType);
+            ticketValidator
+                .ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>())
+                .Returns(Task.FromResult<ICasPrincipal?>(principal));
+            // A store is still registered for UseCasSingleLogout to remove from, but it's never wired into
+            // CookieAuthenticationOptions.SessionStore, so the cookie carries the full ticket, not a store key.
+            var store = new DistributedCacheIAuthenticationSessionStore(
+                new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+                Options.Create(new DistributedCacheIAuthenticationSessionStoreOptions()));
+
+            using var server = TestServer.Create(app =>
+            {
+                app.SetDataProtectionProvider(new FakeDataProtectionProvider(new AesDataProtector("test")));
+                app.SetDefaultSignInAsAuthenticationType(CookieAuthenticationDefaults.AuthenticationType);
+                app.UseCookieAuthentication(new CookieAuthenticationOptions
+                {
+                    LoginPath = CookieAuthenticationDefaults.LoginPath,
+                    LogoutPath = CookieAuthenticationDefaults.LogoutPath
+                });
+                app.UseCasAuthentication(new CasAuthenticationOptions
+                {
+                    ServiceTicketValidator = ticketValidator,
+                    CasServerUrlBase = CasServerUrlBase,
+                    SaveTokens = true
+                });
+                app.Map("/cas-logout", logoutApp => logoutApp.UseCasSingleLogout(store));
+                app.Use(async (context, _) =>
+                {
+                    if (context.Request.Path.Value == "/login")
+                    {
+                        context.Authentication.Challenge(new AuthenticationProperties { RedirectUri = "/" },
+                            CasDefaults.AuthenticationType);
+                        return;
+                    }
+
+                    var user = context.Authentication.User;
+                    context.Response.StatusCode =
+                        user?.Identities.Any(identity => identity.IsAuthenticated) == true ? 200 : 401;
+                    await Task.CompletedTask;
+                });
+            });
+
+            using var challengeResponse =
+                await server.HttpClient.GetAsync("/login", TestContext.Current.CancellationToken);
+            var query = QueryHelpers.ParseQuery(challengeResponse.Headers.Location.Query);
+            var validateUrl =
+                QueryHelpers.AddQueryString(query[Constants.Parameters.Service], Constants.Parameters.Ticket, ticket);
+            using var signInRequest = challengeResponse.GetRequestWithCookies(validateUrl);
+            using var signInResponse =
+                await server.HttpClient.SendAsync(signInRequest, TestContext.Current.CancellationToken);
+
+            // Act
+            using var logoutContent = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["logoutRequest"] =
+                    $@"<samlp:LogoutRequest xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol"" ID=""{Guid.NewGuid()}"" Version=""2.0"" IssueInstant=""{DateTime.UtcNow:o}"">
+    <saml:NameID xmlns:saml=""urn:oasis:names:tc:SAML:2.0:assertion"">@NOT_USED@</saml:NameID>
+    <samlp:SessionIndex>{ticket}</samlp:SessionIndex></samlp:LogoutRequest>"
+            });
+            using var logoutResponse =
+                await server.HttpClient.PostAsync("/cas-logout", logoutContent, TestContext.Current.CancellationToken);
+
+            // Assert: with no SessionStore wired, the cookie is self-contained, so the back-channel logout
+            // removing the (otherwise-unused) store entry has no bearing on it — the session stays valid.
+            using var postLogoutRequest = signInResponse.GetRequestWithCookies("/");
+            using var postLogoutResponse =
+                await server.HttpClient.SendAsync(postLogoutRequest, TestContext.Current.CancellationToken);
+            Assert.Equal(HttpStatusCode.OK, postLogoutResponse.StatusCode);
+        }
+    }
+}

--- a/owin/GSS.Authentication.CAS.Owin.Tests/CasSingleLogoutMiddlewareTests.cs
+++ b/owin/GSS.Authentication.CAS.Owin.Tests/CasSingleLogoutMiddlewareTests.cs
@@ -76,6 +76,31 @@ namespace GSS.Authentication.CAS.Owin.Tests
             await cache.Received(1).RemoveAsync(_options.CacheKeyFactory(ticket), Arg.Any<CancellationToken>());
         }
 
+        [Fact]
+        public async Task WithUntrustedRequest_ShouldNotRemoveTicket()
+        {
+            // Arrange
+            var cache = Substitute.For<IDistributedCache>();
+            using var server = TestServer.Create(app =>
+                app.UseCasSingleLogout(
+                    new DistributedCacheIAuthenticationSessionStore(cache, Options.Create(_options)),
+                    new CasSingleLogoutOptions { IsTrustedRequest = _ => false }));
+            var ticket = Guid.NewGuid().ToString();
+            using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+            {
+                ["logoutRequest"] =
+                    $@"<samlp:LogoutRequest xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol"" ID=""{Guid.NewGuid()}"" Version=""2.0"" IssueInstant=""{DateTime.UtcNow:o}"">
+    <saml:NameID xmlns:saml=""urn:oasis:names:tc:SAML:2.0:assertion"">@NOT_USED@</saml:NameID>
+    <samlp:SessionIndex>{ticket}</samlp:SessionIndex></samlp:LogoutRequest>"
+            });
+
+            // Act
+            using var response = await server.HttpClient.PostAsync("/", content, TestContext.Current.CancellationToken);
+
+            // Assert
+            await cache.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+        }
+
         private TestServer CreateServer(IDistributedCache cache)
         {
             return TestServer.Create(app =>

--- a/src/GSS.Authentication.CAS.AspNetCore/CasSingleLogoutExtensions.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/CasSingleLogoutExtensions.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Options;
 
 namespace GSS.Authentication.CAS.AspNetCore;
 
@@ -9,10 +11,33 @@ namespace GSS.Authentication.CAS.AspNetCore;
 /// </summary>
 public static class CasSingleLogoutExtensions
 {
-    public static IApplicationBuilder UseCasSingleLogout(this IApplicationBuilder app, ITicketStore? store = null)
+    /// <summary>
+    /// Adds <see cref="CasSingleLogoutMiddleware"/> to the pipeline.
+    /// </summary>
+    /// <param name="app"></param>
+    /// <param name="store">
+    /// The ticket store to remove entries from on logout. Resolved from DI when omitted.
+    /// </param>
+    /// <param name="options">Configuration for the middleware. Defaults apply when omitted.</param>
+    public static IApplicationBuilder UseCasSingleLogout(this IApplicationBuilder app, ITicketStore? store = null,
+        CasSingleLogoutOptions? options = null)
     {
         if (app == null)
             throw new ArgumentNullException(nameof(app));
-        return store == null ? app.UseMiddleware<CasSingleLogoutMiddleware>() : app.UseMiddleware<CasSingleLogoutMiddleware>(store);
+
+        // Omit rather than pass null for unset arguments, so ActivatorUtilities can still resolve the
+        // corresponding constructor parameter from DI (a literal null can't be type-matched to a parameter).
+        var args = new List<object>();
+        if (store != null)
+        {
+            args.Add(store);
+        }
+
+        if (options != null)
+        {
+            args.Add(Options.Create(options));
+        }
+
+        return app.UseMiddleware<CasSingleLogoutMiddleware>(args.ToArray());
     }
 }

--- a/src/GSS.Authentication.CAS.AspNetCore/CasSingleLogoutMiddleware.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/CasSingleLogoutMiddleware.cs
@@ -8,9 +8,28 @@ using System.Xml.XPath;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace GSS.Authentication.CAS.AspNetCore;
 
+/// <summary>
+/// Handles the CAS back-channel Single Sign-Out notification: parses the SAML-like <c>logoutRequest</c> the CAS
+/// server POSTs, and removes the matching entry (keyed by the CAS service ticket, i.e. SAML <c>SessionIndex</c>)
+/// from <see cref="ITicketStore"/>.
+/// </summary>
+/// <remarks>
+/// For this to actually end an already-signed-in cookie session, the same <see cref="ITicketStore"/> instance
+/// must also be assigned to <see cref="CookieAuthenticationOptions.SessionStore"/>, and
+/// <c>CasAuthenticationOptions.SaveTokens</c> must be <see langword="true"/> (so the service ticket is
+/// available to key the store by). When wired that way, removing the store entry takes effect on the very next
+/// request that presents the cookie — cookie authentication looks the ticket up in the store on every request,
+/// so there's no polling interval or caching delay to wait out.
+/// <para>
+/// Without that wiring (the default), the cookie itself carries the full encrypted ticket rather than a store
+/// key, so cookie authentication never consults the store at all — removing an entry here has no effect on an
+/// already-issued cookie, which then simply remains valid until it expires or is re-issued.
+/// </para>
+/// </remarks>
 public class CasSingleLogoutMiddleware
 {
     private const string RequestContentType = "application/x-www-form-urlencoded";
@@ -19,19 +38,22 @@ public class CasSingleLogoutMiddleware
     private readonly ITicketStore _store;
     private readonly RequestDelegate _next;
     private readonly ILogger<CasSingleLogoutMiddleware> _logger;
+    private readonly CasSingleLogoutOptions _options;
 
     public CasSingleLogoutMiddleware(RequestDelegate next, ITicketStore store,
-        ILogger<CasSingleLogoutMiddleware> logger)
+        ILogger<CasSingleLogoutMiddleware> logger, IOptions<CasSingleLogoutOptions>? options = null)
     {
         _next = next;
         _store = store;
         _logger = logger;
+        _options = options?.Value ?? new CasSingleLogoutOptions();
     }
 
     public async Task Invoke(HttpContext context)
     {
         if (context.Request.Method.Equals(HttpMethod.Post.Method, StringComparison.OrdinalIgnoreCase)
-            && string.Equals(context.Request.ContentType, RequestContentType, StringComparison.OrdinalIgnoreCase))
+            && string.Equals(context.Request.ContentType, RequestContentType, StringComparison.OrdinalIgnoreCase)
+            && _options.IsTrustedRequest(context))
         {
             var formData = await context.Request.ReadFormAsync(context.RequestAborted).ConfigureAwait(false);
             if (formData.ContainsKey(LogoutRequest))

--- a/src/GSS.Authentication.CAS.AspNetCore/CasSingleLogoutOptions.cs
+++ b/src/GSS.Authentication.CAS.AspNetCore/CasSingleLogoutOptions.cs
@@ -1,0 +1,29 @@
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace GSS.Authentication.CAS.AspNetCore;
+
+/// <summary>
+/// Configuration options for <see cref="CasSingleLogoutMiddleware"/>.
+/// </summary>
+public class CasSingleLogoutOptions
+{
+    /// <summary>
+    /// Called for every incoming request before it's treated as a genuine CAS back-channel logout notification.
+    /// Return <see langword="false"/> to ignore the request without removing anything from the ticket store.
+    /// </summary>
+    /// <remarks>
+    /// The CAS protocol defines the back-channel logout as "fire and forget" with no signature or authentication
+    /// mechanism of its own (CAS Protocol Specification §2.3.3), so this is a client-side hardening hook, not a
+    /// protocol guarantee. Defaults to trusting every request, matching prior behavior.
+    /// <para>
+    /// Example: restrict to requests originating from the configured CAS server's host, resolved once at startup:
+    /// <code>
+    /// var trustedAddresses = await Dns.GetHostAddressesAsync(new Uri(casServerUrlBase).Host);
+    /// options.IsTrustedRequest = context =&gt;
+    ///     context.Connection.RemoteIpAddress != null &amp;&amp; trustedAddresses.Contains(context.Connection.RemoteIpAddress);
+    /// </code>
+    /// </para>
+    /// </remarks>
+    public Func<HttpContext, bool> IsTrustedRequest { get; set; } = _ => true;
+}

--- a/src/GSS.Authentication.CAS.Owin/CasSingleLogoutExtensions.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasSingleLogoutExtensions.cs
@@ -4,15 +4,27 @@ using Owin;
 
 namespace GSS.Authentication.CAS.Owin
 {
+    /// <summary>
+    /// Extension methods for using <see cref="CasSingleLogoutMiddleware"/>
+    /// </summary>
     public static class CasSingleLogoutExtensions
     {
-        public static IAppBuilder UseCasSingleLogout(this IAppBuilder app, IAuthenticationSessionStore store)
+        /// <summary>
+        /// Adds <see cref="CasSingleLogoutMiddleware"/> to the pipeline.
+        /// </summary>
+        /// <param name="app"></param>
+        /// <param name="store">The session store to remove entries from on logout.</param>
+        /// <param name="options">Configuration for the middleware. Defaults apply when omitted.</param>
+        public static IAppBuilder UseCasSingleLogout(this IAppBuilder app, IAuthenticationSessionStore store,
+            CasSingleLogoutOptions? options = null)
         {
             if (app == null)
                 throw new ArgumentNullException(nameof(app));
             if (store == null)
                 throw new ArgumentNullException(nameof(store));
-            return app.Use<CasSingleLogoutMiddleware>(app, store);
+            // Always pass a concrete instance (never a literal null) since IAppBuilder.Use<T> resolves the
+            // middleware constructor by matching argument count/type, not via a DI container.
+            return app.Use<CasSingleLogoutMiddleware>(app, store, options ?? new CasSingleLogoutOptions());
         }
     }
 }

--- a/src/GSS.Authentication.CAS.Owin/CasSingleLogoutMiddleware.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasSingleLogoutMiddleware.cs
@@ -12,6 +12,25 @@ using Owin;
 
 namespace GSS.Authentication.CAS.Owin
 {
+    /// <summary>
+    /// Handles the CAS back-channel Single Sign-Out notification: parses the SAML-like <c>logoutRequest</c> the
+    /// CAS server POSTs, and removes the matching entry (keyed by the CAS service ticket, i.e. SAML
+    /// <c>SessionIndex</c>) from <see cref="IAuthenticationSessionStore"/>.
+    /// </summary>
+    /// <remarks>
+    /// For this to actually end an already-signed-in cookie session, the same
+    /// <see cref="IAuthenticationSessionStore"/> instance must also be assigned to
+    /// <see cref="CookieAuthenticationOptions.SessionStore"/>, and <see cref="CasAuthenticationOptions.SaveTokens"/>
+    /// must be <see langword="true"/> (so the service ticket is available to key the store by). When wired that
+    /// way, removing the store entry takes effect on the very next request that presents the cookie — cookie
+    /// authentication looks the ticket up in the store on every request, so there's no polling interval or
+    /// caching delay to wait out.
+    /// <para>
+    /// Without that wiring (the default), the cookie itself carries the full encrypted ticket rather than a
+    /// store key, so cookie authentication never consults the store at all — removing an entry here has no
+    /// effect on an already-issued cookie, which then simply remains valid until it expires or is re-issued.
+    /// </para>
+    /// </remarks>
     public class CasSingleLogoutMiddleware : OwinMiddleware
     {
         private const string RequestContentType = "application/x-www-form-urlencoded";
@@ -19,21 +38,25 @@ namespace GSS.Authentication.CAS.Owin
         private static readonly XmlNamespaceManager _xmlNamespaceManager = InitializeXmlNamespaceManager();
         private readonly IAuthenticationSessionStore _store;
         private readonly ILogger _logger;
+        private readonly CasSingleLogoutOptions _options;
 
         public CasSingleLogoutMiddleware(
             OwinMiddleware next,
             IAppBuilder app,
-            IAuthenticationSessionStore store
+            IAuthenticationSessionStore store,
+            CasSingleLogoutOptions? options = null
         ) : base(next)
         {
             _logger = app.CreateLogger<CasSingleLogoutMiddleware>();
             _store = store;
+            _options = options ?? new CasSingleLogoutOptions();
         }
 
         public override async Task Invoke(IOwinContext context)
         {
             if (context.Request.Method.Equals(HttpMethod.Post.Method, StringComparison.OrdinalIgnoreCase)
-                && string.Equals(context.Request.ContentType, RequestContentType, StringComparison.OrdinalIgnoreCase))
+                && string.Equals(context.Request.ContentType, RequestContentType, StringComparison.OrdinalIgnoreCase)
+                && _options.IsTrustedRequest(context))
             {
                 var formData = await context.Request.ReadFormAsync().ConfigureAwait(false);
                 var logoutRequest = formData.FirstOrDefault(x => x.Key == LogoutRequest).Value?[0] ?? string.Empty;

--- a/src/GSS.Authentication.CAS.Owin/CasSingleLogoutOptions.cs
+++ b/src/GSS.Authentication.CAS.Owin/CasSingleLogoutOptions.cs
@@ -1,0 +1,35 @@
+using System;
+using Microsoft.Owin;
+
+namespace GSS.Authentication.CAS.Owin
+{
+    /// <summary>
+    /// Configuration options for <see cref="CasSingleLogoutMiddleware"/>.
+    /// </summary>
+    public class CasSingleLogoutOptions
+    {
+        /// <summary>
+        /// Called for every incoming request before it's treated as a genuine CAS back-channel logout
+        /// notification. Return <see langword="false"/> to ignore the request without removing anything from
+        /// the ticket store.
+        /// </summary>
+        /// <remarks>
+        /// The CAS protocol defines the back-channel logout as "fire and forget" with no signature or
+        /// authentication mechanism of its own (CAS Protocol Specification §2.3.3), so this is a client-side
+        /// hardening hook, not a protocol guarantee. Defaults to trusting every request, matching prior behavior.
+        /// <para>
+        /// Example: restrict to requests originating from the configured CAS server's host, resolved once at
+        /// startup:
+        /// <code>
+        /// var trustedAddresses = await Dns.GetHostAddressesAsync(new Uri(casServerUrlBase).Host);
+        /// options.IsTrustedRequest = context =&gt;
+        /// {
+        ///     var remoteIp = context.Request.RemoteIpAddress;
+        ///     return remoteIp != null &amp;&amp; trustedAddresses.Contains(IPAddress.Parse(remoteIp));
+        /// };
+        /// </code>
+        /// </para>
+        /// </remarks>
+        public Func<IOwinContext, bool> IsTrustedRequest { get; set; } = _ => true;
+    }
+}

--- a/test/GSS.Authentication.CAS.AspNetCore.Tests/CasSingleLogoutIntegrationTests.cs
+++ b/test/GSS.Authentication.CAS.AspNetCore.Tests/CasSingleLogoutIntegrationTests.cs
@@ -1,0 +1,183 @@
+using System.Net;
+using GSS.Authentication.CAS.Security;
+using GSS.Authentication.CAS.Validation;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace GSS.Authentication.CAS.AspNetCore.Tests;
+
+/// <summary>
+/// End-to-end proof of exactly when a back-channel CAS logout takes effect on an already-signed-in cookie
+/// session, backed by <see cref="DistributedCacheTicketStore"/> as the cookie authentication's session store.
+/// </summary>
+public class CasSingleLogoutIntegrationTests
+{
+    private const string CasServerUrlBase = "https://cas.example.org/cas";
+
+    [Fact]
+    public async Task SignedInSession_AfterBackChannelLogout_ShouldBeUnauthenticatedOnNextRequest()
+    {
+        // Arrange
+        var ticketValidator = Substitute.For<IServiceTicketValidator>();
+        var ticket = Guid.NewGuid().ToString();
+        var principal = new CasPrincipal(new Assertion(Guid.NewGuid().ToString()), CasDefaults.AuthenticationType);
+        ticketValidator
+            .ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ICasPrincipal?>(principal));
+        var store = new DistributedCacheTicketStore(
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            Options.Create(new DistributedCacheTicketStoreOptions()));
+
+        using var host = new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+                    .AddCAS(options =>
+                    {
+                        options.ServiceTicketValidator = ticketValidator;
+                        options.CasServerUrlBase = CasServerUrlBase;
+                        options.SaveTokens = true;
+                    })
+                    .AddCookie(options => options.SessionStore = store);
+            })
+            .ConfigureWebHost(webHostBuilder => webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    app.UseAuthentication();
+                    app.Map("/login", loginApp => loginApp.Run(context =>
+                        context.ChallengeAsync(CasDefaults.AuthenticationType,
+                            new AuthenticationProperties { RedirectUri = "/" })));
+                    app.Map("/cas-logout", logoutApp => logoutApp.UseCasSingleLogout(store));
+                    app.Run(context =>
+                    {
+                        context.Response.StatusCode =
+                            context.User.Identity?.IsAuthenticated == true
+                                ? (int)HttpStatusCode.OK
+                                : (int)HttpStatusCode.Unauthorized;
+                        return Task.CompletedTask;
+                    });
+                }))
+            .Build();
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+
+        using var challengeResponse = await client.GetAsync("/login", TestContext.Current.CancellationToken);
+        var query = QueryHelpers.ParseQuery(challengeResponse.Headers.Location?.Query);
+        var validateUrl =
+            QueryHelpers.AddQueryString(query[Constants.Parameters.Service]!, Constants.Parameters.Ticket, ticket);
+        using var signInRequest = challengeResponse.GetRequestWithCookies(validateUrl);
+        using var signInResponse = await client.SendAsync(signInRequest, TestContext.Current.CancellationToken);
+
+        using var authorizedRequest = signInResponse.GetRequestWithCookies("/");
+        using var authorizedResponse =
+            await client.SendAsync(authorizedRequest, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, authorizedResponse.StatusCode);
+
+        // Act
+        using var logoutContent = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["logoutRequest"] =
+                $@"<samlp:LogoutRequest xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol"" ID=""{Guid.NewGuid()}"" Version=""2.0"" IssueInstant=""{DateTime.UtcNow:o}"">
+    <saml:NameID xmlns:saml=""urn:oasis:names:tc:SAML:2.0:assertion"">@NOT_USED@</saml:NameID>
+    <samlp:SessionIndex>{ticket}</samlp:SessionIndex></samlp:LogoutRequest>"
+        });
+        using var logoutResponse = await client.PostAsync("/cas-logout", logoutContent, TestContext.Current.CancellationToken);
+
+        // Assert: the very next request with the same (still unexpired) cookie is no longer authenticated —
+        // removing the session-store entry takes effect immediately, with no polling interval or caching delay.
+        using var postLogoutRequest = signInResponse.GetRequestWithCookies("/");
+        using var postLogoutResponse =
+            await client.SendAsync(postLogoutRequest, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.Unauthorized, postLogoutResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task SignedInSession_WithoutSessionStoreWired_ShouldStayAuthenticatedAfterBackChannelLogout()
+    {
+        // Arrange
+        var ticketValidator = Substitute.For<IServiceTicketValidator>();
+        var ticket = Guid.NewGuid().ToString();
+        var principal = new CasPrincipal(new Assertion(Guid.NewGuid().ToString()), CasDefaults.AuthenticationType);
+        ticketValidator
+            .ValidateAsync(ticket, Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<ICasPrincipal?>(principal));
+        // A store is still registered for UseCasSingleLogout to remove from, but it's never wired into
+        // CookieAuthenticationOptions.SessionStore, so the cookie carries the full ticket, not a store key.
+        var store = new DistributedCacheTicketStore(
+            new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions())),
+            Options.Create(new DistributedCacheTicketStoreOptions()));
+
+        using var host = new HostBuilder()
+            .ConfigureServices(services =>
+            {
+                services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+                    .AddCAS(options =>
+                    {
+                        options.ServiceTicketValidator = ticketValidator;
+                        options.CasServerUrlBase = CasServerUrlBase;
+                        options.SaveTokens = true;
+                    })
+                    .AddCookie();
+            })
+            .ConfigureWebHost(webHostBuilder => webHostBuilder
+                .UseTestServer()
+                .Configure(app =>
+                {
+                    app.UseAuthentication();
+                    app.Map("/login", loginApp => loginApp.Run(context =>
+                        context.ChallengeAsync(CasDefaults.AuthenticationType,
+                            new AuthenticationProperties { RedirectUri = "/" })));
+                    app.Map("/cas-logout", logoutApp => logoutApp.UseCasSingleLogout(store));
+                    app.Run(context =>
+                    {
+                        context.Response.StatusCode =
+                            context.User.Identity?.IsAuthenticated == true
+                                ? (int)HttpStatusCode.OK
+                                : (int)HttpStatusCode.Unauthorized;
+                        return Task.CompletedTask;
+                    });
+                }))
+            .Build();
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+
+        using var challengeResponse = await client.GetAsync("/login", TestContext.Current.CancellationToken);
+        var query = QueryHelpers.ParseQuery(challengeResponse.Headers.Location?.Query);
+        var validateUrl =
+            QueryHelpers.AddQueryString(query[Constants.Parameters.Service]!, Constants.Parameters.Ticket, ticket);
+        using var signInRequest = challengeResponse.GetRequestWithCookies(validateUrl);
+        using var signInResponse = await client.SendAsync(signInRequest, TestContext.Current.CancellationToken);
+
+        // Act
+        using var logoutContent = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["logoutRequest"] =
+                $@"<samlp:LogoutRequest xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol"" ID=""{Guid.NewGuid()}"" Version=""2.0"" IssueInstant=""{DateTime.UtcNow:o}"">
+    <saml:NameID xmlns:saml=""urn:oasis:names:tc:SAML:2.0:assertion"">@NOT_USED@</saml:NameID>
+    <samlp:SessionIndex>{ticket}</samlp:SessionIndex></samlp:LogoutRequest>"
+        });
+        using var logoutResponse = await client.PostAsync("/cas-logout", logoutContent, TestContext.Current.CancellationToken);
+
+        // Assert: with no SessionStore wired, the cookie is self-contained, so the back-channel logout removing
+        // the (otherwise-unused) store entry has no bearing on it — the session stays valid.
+        using var postLogoutRequest = signInResponse.GetRequestWithCookies("/");
+        using var postLogoutResponse =
+            await client.SendAsync(postLogoutRequest, TestContext.Current.CancellationToken);
+        Assert.Equal(HttpStatusCode.OK, postLogoutResponse.StatusCode);
+    }
+}

--- a/test/GSS.Authentication.CAS.AspNetCore.Tests/CasSingleLogoutMiddlewareTests.cs
+++ b/test/GSS.Authentication.CAS.AspNetCore.Tests/CasSingleLogoutMiddlewareTests.cs
@@ -88,6 +88,39 @@ public class CasSingleLogoutMiddlewareTests
     }
 
     [Fact]
+    public async Task WithUntrustedRequest_ShouldNotRemoveTicket()
+    {
+        // Arrange
+        var cache = Substitute.For<IDistributedCache>();
+        var host = new HostBuilder()
+            .ConfigureWebHostDefaults(builder =>
+            {
+                builder.UseTestServer();
+                builder.Configure(app => app.UseCasSingleLogout(
+                    new DistributedCacheTicketStore(cache, Options.Create(_options)),
+                    new CasSingleLogoutOptions { IsTrustedRequest = _ => false }));
+            })
+            .Build();
+        var server = host.GetTestServer();
+        await host.StartAsync(TestContext.Current.CancellationToken);
+        using var client = server.CreateClient();
+        var ticket = Guid.NewGuid().ToString();
+        using var content = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["logoutRequest"] =
+                $@"<samlp:LogoutRequest xmlns:samlp=""urn:oasis:names:tc:SAML:2.0:protocol"" ID=""{Guid.NewGuid()}"" Version=""2.0"" IssueInstant=""{DateTime.UtcNow:o}"">
+    <saml:NameID xmlns:saml=""urn:oasis:names:tc:SAML:2.0:assertion"">@NOT_USED@</saml:NameID>
+    <samlp:SessionIndex>{ticket}</samlp:SessionIndex></samlp:LogoutRequest>"
+        });
+
+        // Act
+        using var response = await client.PostAsync("/", content, TestContext.Current.CancellationToken);
+
+        // Assert
+        await cache.DidNotReceive().RemoveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task RetrievedTicketStoreFromDI_ShouldNotThrows()
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Add a configurable `IsTrustedRequest` hook to `CasSingleLogoutOptions` (both ASP.NET Core and OWIN), checked before an incoming `logoutRequest` POST is trusted and acted on. Defaults to trusting every request (no behavior change unless configured) — the CAS back-channel logout has no signature/authentication mechanism of its own, so this is a client-side hardening hook, not a protocol guarantee.
- Verify and document exactly when a back-channel logout ends an already-signed-in cookie session, via two new end-to-end tests per package:
  - **Wired** (`CookieAuthenticationOptions.SessionStore` set to the same store + `SaveTokens=true`): removal takes effect on the very next request presenting the cookie — no polling interval or caching delay.
  - **Un-wired** (the default): the cookie carries the full ticket rather than a store key, so the store is never consulted — the session stays valid until the cookie itself expires.
- Both behaviors are now documented on `CasSingleLogoutMiddleware`'s XML doc comments.

Part of #1035. Closes #1034

## Test plan
- [x] `dotnet build` (0 warnings, all TFMs)
- [x] `dotnet test --filter "FullyQualifiedName!~E2E"` (302 passed, includes the 4 new SLO integration/unit tests on the ASP.NET Core side, verified to actually pass locally — the "wired" and "un-wired" claims are empirically proven, not just asserted)
- [x] OWIN package + tests build clean; the mirrored OWIN integration tests could not be executed locally (no Mono on this machine) and rely on CI
- [x] `/code-review` (Standards + Spec axes) — findings addressed: added the missing "un-wired default" documentation + a test proving it (the Spec review flagged this as the one real gap), added XML docs to the `UseCasSingleLogout` extension methods, fixed a non-compiling doc-comment example in OWIN's `CasSingleLogoutOptions`, added a trailing newline. One noted-but-accepted point: the hardening hook is opt-in and silent by design (no default behavior change), so an operator who never configures `IsTrustedRequest` gets no origin validation and no warning about that — this matches the issue's explicit "make it configurable" resolution path.