### PR TITLE
feat: add public-API approval test using Microsoft.CodeAnalysis.PublicApiAnalyzers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,6 +41,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="$(MicrosoftAspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(MicrosoftAspNetCoreVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform" Version="4.1.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EntityFrameworkCoreVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(EntityFrameworkCoreVersion)" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -34,4 +34,20 @@
     <None Include="$(MSBuildThisFileDirectory)../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="Exists('$(MSBuildProjectDirectory)/PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt')">
+    <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI/$(TargetFramework)/PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+  <ItemGroup Condition="!Exists('$(MSBuildProjectDirectory)/PublicAPI/$(TargetFramework)/PublicAPI.Shipped.txt') and Exists('$(MSBuildProjectDirectory)/PublicAPI.Shipped.txt')">
+    <AdditionalFiles Include="PublicAPI.Shipped.txt" />
+    <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
+  </ItemGroup>
+
 </Project>

--- a/src/GSS.Authentication.CAS.AspNetCore/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/GSS.Authentication.CAS.AspNetCore/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1,0 +1,91 @@
+#nullable enable
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.CasAuthenticationHandler(Microsoft.Extensions.Options.IOptionsMonitor<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>! options, Microsoft.Extensions.Logging.ILoggerFactory! logger, System.Text.Encodings.Web.UrlEncoder! encoder) -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.Events.get -> GSS.Authentication.CAS.AspNetCore.CasEvents!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.Events.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.SignOutAsync(Microsoft.AspNetCore.Authentication.AuthenticationProperties? properties) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.AuthenticationType.get -> string!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.CasAuthenticationOptions() -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.CasServerUrlBase.get -> string!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.CasServerUrlBase.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Events.get -> GSS.Authentication.CAS.AspNetCore.CasEvents!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Events.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Gateway.get -> bool
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Gateway.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Locale.get -> string?
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Locale.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Method.get -> string?
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Method.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ProxyCallbackPath.get -> Microsoft.AspNetCore.Http.PathString
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ProxyCallbackPath.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ProxyGrantingTicketStore.get -> GSS.Authentication.CAS.Proxy.IProxyGrantingTicketStore!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ProxyGrantingTicketStore.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Renew.get -> bool
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Renew.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ServiceTicketValidator.get -> GSS.Authentication.CAS.Validation.IServiceTicketValidator!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ServiceTicketValidator.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.SignedOutCallbackPath.get -> Microsoft.AspNetCore.Http.PathString
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.SignedOutCallbackPath.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.SignedOutRedirectUri.get -> string!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.SignedOutRedirectUri.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.StateDataFormat.get -> Microsoft.AspNetCore.Authentication.ISecureDataFormat<Microsoft.AspNetCore.Authentication.AuthenticationProperties!>!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.StateDataFormat.set -> void
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext.Assertion.get -> GSS.Authentication.CAS.Security.Assertion!
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext.Backchannel.get -> System.Net.Http.HttpClient!
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext.CasCreatingTicketContext(System.Security.Claims.ClaimsPrincipal! principal, Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties, Microsoft.AspNetCore.Http.HttpContext! context, Microsoft.AspNetCore.Authentication.AuthenticationScheme! scheme, GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions! options, System.Net.Http.HttpClient! backchannel, GSS.Authentication.CAS.Security.Assertion! assertion) -> void
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext.Identity.get -> System.Security.Claims.ClaimsIdentity?
+GSS.Authentication.CAS.AspNetCore.CasEvents
+GSS.Authentication.CAS.AspNetCore.CasEvents.CasEvents() -> void
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnCreatingTicket.get -> System.Func<GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnCreatingTicket.set -> void
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnRedirectToAuthorizationEndpoint.get -> System.Func<Microsoft.AspNetCore.Authentication.RedirectContext<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnRedirectToAuthorizationEndpoint.set -> void
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnRedirectToIdentityProviderForSignOut.get -> System.Func<GSS.Authentication.CAS.AspNetCore.CasRedirectContext!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnRedirectToIdentityProviderForSignOut.set -> void
+GSS.Authentication.CAS.AspNetCore.CasExtensions
+GSS.Authentication.CAS.AspNetCore.CasRedirectContext
+GSS.Authentication.CAS.AspNetCore.CasRedirectContext.CasRedirectContext(Microsoft.AspNetCore.Http.HttpContext! context, Microsoft.AspNetCore.Authentication.AuthenticationScheme! scheme, GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions! options, Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties, string! redirectUri) -> void
+GSS.Authentication.CAS.AspNetCore.CasRedirectContext.Handled.get -> bool
+GSS.Authentication.CAS.AspNetCore.CasRedirectContext.HandleResponse() -> void
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutExtensions
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware.CasSingleLogoutMiddleware(Microsoft.AspNetCore.Http.RequestDelegate! next, Microsoft.AspNetCore.Authentication.Cookies.ITicketStore! store, Microsoft.Extensions.Logging.ILogger<GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware!>! logger, Microsoft.Extensions.Options.IOptions<GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions!>? options = null) -> void
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware.Invoke(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions.CasSingleLogoutOptions() -> void
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions.IsTrustedRequest.get -> System.Func<Microsoft.AspNetCore.Http.HttpContext!, bool>!
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions.IsTrustedRequest.set -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.DistributedCacheTicketStore(Microsoft.Extensions.Caching.Distributed.IDistributedCache! cache, Microsoft.Extensions.Options.IOptions<GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions!>! options) -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.RemoveAsync(string! key) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.RenewAsync(string! key, Microsoft.AspNetCore.Authentication.AuthenticationTicket! ticket) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.RetrieveAsync(string! key) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Authentication.AuthenticationTicket?>!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.StoreAsync(Microsoft.AspNetCore.Authentication.AuthenticationTicket! ticket) -> System.Threading.Tasks.Task<string!>!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.CacheEntryOptions.get -> Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.CacheEntryOptions.set -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.CacheKeyFactory.get -> System.Func<string!, string!>!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.CacheKeyFactory.set -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.DistributedCacheTicketStoreOptions() -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.SerializerOptions.get -> System.Text.Json.JsonSerializerOptions?
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.SerializerOptions.set -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.TicketIdFactory.get -> System.Func<Microsoft.AspNetCore.Authentication.AuthenticationTicket!, string!>!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.TicketIdFactory.set -> void
+GSS.Authentication.CAS.AspNetCore.ServiceTicketPropertiesExtensions
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.CreateEventsAsync() -> System.Threading.Tasks.Task<object!>!
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.HandleChallengeAsync(Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties) -> System.Threading.Tasks.Task!
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.HandleRemoteAuthenticateAsync() -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Authentication.HandleRequestResult!>!
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.HandleRequestAsync() -> System.Threading.Tasks.Task<bool>!
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Validate() -> void
+static GSS.Authentication.CAS.AspNetCore.CasExtensions.AddCAS(this Microsoft.AspNetCore.Authentication.AuthenticationBuilder! builder) -> Microsoft.AspNetCore.Authentication.AuthenticationBuilder!
+static GSS.Authentication.CAS.AspNetCore.CasExtensions.AddCAS(this Microsoft.AspNetCore.Authentication.AuthenticationBuilder! builder, string! authenticationScheme, string! displayName, System.Action<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>? configureOptions) -> Microsoft.AspNetCore.Authentication.AuthenticationBuilder!
+static GSS.Authentication.CAS.AspNetCore.CasExtensions.AddCAS(this Microsoft.AspNetCore.Authentication.AuthenticationBuilder! builder, string! authenticationScheme, System.Action<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>? configureOptions) -> Microsoft.AspNetCore.Authentication.AuthenticationBuilder!
+static GSS.Authentication.CAS.AspNetCore.CasExtensions.AddCAS(this Microsoft.AspNetCore.Authentication.AuthenticationBuilder! builder, System.Action<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>? configureOptions) -> Microsoft.AspNetCore.Authentication.AuthenticationBuilder!
+static GSS.Authentication.CAS.AspNetCore.CasSingleLogoutExtensions.UseCasSingleLogout(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, Microsoft.AspNetCore.Authentication.Cookies.ITicketStore? store = null, GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions? options = null) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
+static GSS.Authentication.CAS.AspNetCore.ServiceTicketPropertiesExtensions.GetServiceTicket(this Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties) -> string?
+static GSS.Authentication.CAS.AspNetCore.ServiceTicketPropertiesExtensions.SetServiceTicket(this Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties, string! ticket) -> void
+virtual GSS.Authentication.CAS.AspNetCore.CasEvents.CreatingTicket(GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext! context) -> System.Threading.Tasks.Task!
+virtual GSS.Authentication.CAS.AspNetCore.CasEvents.RedirectToAuthorizationEndpoint(Microsoft.AspNetCore.Authentication.RedirectContext<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>! context) -> System.Threading.Tasks.Task!
+virtual GSS.Authentication.CAS.AspNetCore.CasEvents.RedirectToIdentityProviderForSignOut(GSS.Authentication.CAS.AspNetCore.CasRedirectContext! context) -> System.Threading.Tasks.Task!

--- a/src/GSS.Authentication.CAS.AspNetCore/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/GSS.Authentication.CAS.AspNetCore/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/GSS.Authentication.CAS.AspNetCore/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/GSS.Authentication.CAS.AspNetCore/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,0 +1,91 @@
+#nullable enable
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.CasAuthenticationHandler(Microsoft.Extensions.Options.IOptionsMonitor<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>! options, Microsoft.Extensions.Logging.ILoggerFactory! logger, System.Text.Encodings.Web.UrlEncoder! encoder) -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.Events.get -> GSS.Authentication.CAS.AspNetCore.CasEvents!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.Events.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.SignOutAsync(Microsoft.AspNetCore.Authentication.AuthenticationProperties? properties) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.AuthenticationType.get -> string!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.CasAuthenticationOptions() -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.CasServerUrlBase.get -> string!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.CasServerUrlBase.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Events.get -> GSS.Authentication.CAS.AspNetCore.CasEvents!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Events.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Gateway.get -> bool
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Gateway.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Locale.get -> string?
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Locale.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Method.get -> string?
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Method.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ProxyCallbackPath.get -> Microsoft.AspNetCore.Http.PathString
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ProxyCallbackPath.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ProxyGrantingTicketStore.get -> GSS.Authentication.CAS.Proxy.IProxyGrantingTicketStore!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ProxyGrantingTicketStore.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Renew.get -> bool
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Renew.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ServiceTicketValidator.get -> GSS.Authentication.CAS.Validation.IServiceTicketValidator!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ServiceTicketValidator.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.SignedOutCallbackPath.get -> Microsoft.AspNetCore.Http.PathString
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.SignedOutCallbackPath.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.SignedOutRedirectUri.get -> string!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.SignedOutRedirectUri.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.StateDataFormat.get -> Microsoft.AspNetCore.Authentication.ISecureDataFormat<Microsoft.AspNetCore.Authentication.AuthenticationProperties!>!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.StateDataFormat.set -> void
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext.Assertion.get -> GSS.Authentication.CAS.Security.Assertion!
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext.Backchannel.get -> System.Net.Http.HttpClient!
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext.CasCreatingTicketContext(System.Security.Claims.ClaimsPrincipal! principal, Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties, Microsoft.AspNetCore.Http.HttpContext! context, Microsoft.AspNetCore.Authentication.AuthenticationScheme! scheme, GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions! options, System.Net.Http.HttpClient! backchannel, GSS.Authentication.CAS.Security.Assertion! assertion) -> void
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext.Identity.get -> System.Security.Claims.ClaimsIdentity?
+GSS.Authentication.CAS.AspNetCore.CasEvents
+GSS.Authentication.CAS.AspNetCore.CasEvents.CasEvents() -> void
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnCreatingTicket.get -> System.Func<GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnCreatingTicket.set -> void
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnRedirectToAuthorizationEndpoint.get -> System.Func<Microsoft.AspNetCore.Authentication.RedirectContext<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnRedirectToAuthorizationEndpoint.set -> void
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnRedirectToIdentityProviderForSignOut.get -> System.Func<GSS.Authentication.CAS.AspNetCore.CasRedirectContext!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnRedirectToIdentityProviderForSignOut.set -> void
+GSS.Authentication.CAS.AspNetCore.CasExtensions
+GSS.Authentication.CAS.AspNetCore.CasRedirectContext
+GSS.Authentication.CAS.AspNetCore.CasRedirectContext.CasRedirectContext(Microsoft.AspNetCore.Http.HttpContext! context, Microsoft.AspNetCore.Authentication.AuthenticationScheme! scheme, GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions! options, Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties, string! redirectUri) -> void
+GSS.Authentication.CAS.AspNetCore.CasRedirectContext.Handled.get -> bool
+GSS.Authentication.CAS.AspNetCore.CasRedirectContext.HandleResponse() -> void
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutExtensions
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware.CasSingleLogoutMiddleware(Microsoft.AspNetCore.Http.RequestDelegate! next, Microsoft.AspNetCore.Authentication.Cookies.ITicketStore! store, Microsoft.Extensions.Logging.ILogger<GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware!>! logger, Microsoft.Extensions.Options.IOptions<GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions!>? options = null) -> void
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware.Invoke(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions.CasSingleLogoutOptions() -> void
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions.IsTrustedRequest.get -> System.Func<Microsoft.AspNetCore.Http.HttpContext!, bool>!
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions.IsTrustedRequest.set -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.DistributedCacheTicketStore(Microsoft.Extensions.Caching.Distributed.IDistributedCache! cache, Microsoft.Extensions.Options.IOptions<GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions!>! options) -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.RemoveAsync(string! key) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.RenewAsync(string! key, Microsoft.AspNetCore.Authentication.AuthenticationTicket! ticket) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.RetrieveAsync(string! key) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Authentication.AuthenticationTicket?>!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.StoreAsync(Microsoft.AspNetCore.Authentication.AuthenticationTicket! ticket) -> System.Threading.Tasks.Task<string!>!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.CacheEntryOptions.get -> Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.CacheEntryOptions.set -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.CacheKeyFactory.get -> System.Func<string!, string!>!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.CacheKeyFactory.set -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.DistributedCacheTicketStoreOptions() -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.SerializerOptions.get -> System.Text.Json.JsonSerializerOptions?
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.SerializerOptions.set -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.TicketIdFactory.get -> System.Func<Microsoft.AspNetCore.Authentication.AuthenticationTicket!, string!>!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.TicketIdFactory.set -> void
+GSS.Authentication.CAS.AspNetCore.ServiceTicketPropertiesExtensions
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.CreateEventsAsync() -> System.Threading.Tasks.Task<object!>!
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.HandleChallengeAsync(Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties) -> System.Threading.Tasks.Task!
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.HandleRemoteAuthenticateAsync() -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Authentication.HandleRequestResult!>!
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.HandleRequestAsync() -> System.Threading.Tasks.Task<bool>!
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Validate() -> void
+static GSS.Authentication.CAS.AspNetCore.CasExtensions.AddCAS(this Microsoft.AspNetCore.Authentication.AuthenticationBuilder! builder) -> Microsoft.AspNetCore.Authentication.AuthenticationBuilder!
+static GSS.Authentication.CAS.AspNetCore.CasExtensions.AddCAS(this Microsoft.AspNetCore.Authentication.AuthenticationBuilder! builder, string! authenticationScheme, string! displayName, System.Action<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>? configureOptions) -> Microsoft.AspNetCore.Authentication.AuthenticationBuilder!
+static GSS.Authentication.CAS.AspNetCore.CasExtensions.AddCAS(this Microsoft.AspNetCore.Authentication.AuthenticationBuilder! builder, string! authenticationScheme, System.Action<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>? configureOptions) -> Microsoft.AspNetCore.Authentication.AuthenticationBuilder!
+static GSS.Authentication.CAS.AspNetCore.CasExtensions.AddCAS(this Microsoft.AspNetCore.Authentication.AuthenticationBuilder! builder, System.Action<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>? configureOptions) -> Microsoft.AspNetCore.Authentication.AuthenticationBuilder!
+static GSS.Authentication.CAS.AspNetCore.CasSingleLogoutExtensions.UseCasSingleLogout(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, Microsoft.AspNetCore.Authentication.Cookies.ITicketStore? store = null, GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions? options = null) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
+static GSS.Authentication.CAS.AspNetCore.ServiceTicketPropertiesExtensions.GetServiceTicket(this Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties) -> string?
+static GSS.Authentication.CAS.AspNetCore.ServiceTicketPropertiesExtensions.SetServiceTicket(this Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties, string! ticket) -> void
+virtual GSS.Authentication.CAS.AspNetCore.CasEvents.CreatingTicket(GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext! context) -> System.Threading.Tasks.Task!
+virtual GSS.Authentication.CAS.AspNetCore.CasEvents.RedirectToAuthorizationEndpoint(Microsoft.AspNetCore.Authentication.RedirectContext<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>! context) -> System.Threading.Tasks.Task!
+virtual GSS.Authentication.CAS.AspNetCore.CasEvents.RedirectToIdentityProviderForSignOut(GSS.Authentication.CAS.AspNetCore.CasRedirectContext! context) -> System.Threading.Tasks.Task!

--- a/src/GSS.Authentication.CAS.AspNetCore/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/GSS.Authentication.CAS.AspNetCore/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/GSS.Authentication.CAS.AspNetCore/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
+++ b/src/GSS.Authentication.CAS.AspNetCore/PublicAPI/netcoreapp3.1/PublicAPI.Shipped.txt
@@ -1,0 +1,91 @@
+#nullable enable
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.CasAuthenticationHandler(Microsoft.Extensions.Options.IOptionsMonitor<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>! options, Microsoft.Extensions.Logging.ILoggerFactory! logger, System.Text.Encodings.Web.UrlEncoder! encoder, Microsoft.AspNetCore.Authentication.ISystemClock! clock) -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.Events.get -> GSS.Authentication.CAS.AspNetCore.CasEvents!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.Events.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.SignOutAsync(Microsoft.AspNetCore.Authentication.AuthenticationProperties? properties) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.AuthenticationType.get -> string!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.CasAuthenticationOptions() -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.CasServerUrlBase.get -> string!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.CasServerUrlBase.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Events.get -> GSS.Authentication.CAS.AspNetCore.CasEvents!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Events.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Gateway.get -> bool
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Gateway.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Locale.get -> string?
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Locale.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Method.get -> string?
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Method.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ProxyCallbackPath.get -> Microsoft.AspNetCore.Http.PathString
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ProxyCallbackPath.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ProxyGrantingTicketStore.get -> GSS.Authentication.CAS.Proxy.IProxyGrantingTicketStore!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ProxyGrantingTicketStore.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Renew.get -> bool
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Renew.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ServiceTicketValidator.get -> GSS.Authentication.CAS.Validation.IServiceTicketValidator!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.ServiceTicketValidator.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.SignedOutCallbackPath.get -> Microsoft.AspNetCore.Http.PathString
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.SignedOutCallbackPath.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.SignedOutRedirectUri.get -> string!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.SignedOutRedirectUri.set -> void
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.StateDataFormat.get -> Microsoft.AspNetCore.Authentication.ISecureDataFormat<Microsoft.AspNetCore.Authentication.AuthenticationProperties!>!
+GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.StateDataFormat.set -> void
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext.Assertion.get -> GSS.Authentication.CAS.Security.Assertion!
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext.Backchannel.get -> System.Net.Http.HttpClient!
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext.CasCreatingTicketContext(System.Security.Claims.ClaimsPrincipal! principal, Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties, Microsoft.AspNetCore.Http.HttpContext! context, Microsoft.AspNetCore.Authentication.AuthenticationScheme! scheme, GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions! options, System.Net.Http.HttpClient! backchannel, GSS.Authentication.CAS.Security.Assertion! assertion) -> void
+GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext.Identity.get -> System.Security.Claims.ClaimsIdentity?
+GSS.Authentication.CAS.AspNetCore.CasEvents
+GSS.Authentication.CAS.AspNetCore.CasEvents.CasEvents() -> void
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnCreatingTicket.get -> System.Func<GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnCreatingTicket.set -> void
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnRedirectToAuthorizationEndpoint.get -> System.Func<Microsoft.AspNetCore.Authentication.RedirectContext<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnRedirectToAuthorizationEndpoint.set -> void
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnRedirectToIdentityProviderForSignOut.get -> System.Func<GSS.Authentication.CAS.AspNetCore.CasRedirectContext!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.AspNetCore.CasEvents.OnRedirectToIdentityProviderForSignOut.set -> void
+GSS.Authentication.CAS.AspNetCore.CasExtensions
+GSS.Authentication.CAS.AspNetCore.CasRedirectContext
+GSS.Authentication.CAS.AspNetCore.CasRedirectContext.CasRedirectContext(Microsoft.AspNetCore.Http.HttpContext! context, Microsoft.AspNetCore.Authentication.AuthenticationScheme! scheme, GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions! options, Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties, string! redirectUri) -> void
+GSS.Authentication.CAS.AspNetCore.CasRedirectContext.Handled.get -> bool
+GSS.Authentication.CAS.AspNetCore.CasRedirectContext.HandleResponse() -> void
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutExtensions
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware.CasSingleLogoutMiddleware(Microsoft.AspNetCore.Http.RequestDelegate! next, Microsoft.AspNetCore.Authentication.Cookies.ITicketStore! store, Microsoft.Extensions.Logging.ILogger<GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware!>! logger, Microsoft.Extensions.Options.IOptions<GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions!>? options = null) -> void
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutMiddleware.Invoke(Microsoft.AspNetCore.Http.HttpContext! context) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions.CasSingleLogoutOptions() -> void
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions.IsTrustedRequest.get -> System.Func<Microsoft.AspNetCore.Http.HttpContext!, bool>!
+GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions.IsTrustedRequest.set -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.DistributedCacheTicketStore(Microsoft.Extensions.Caching.Distributed.IDistributedCache! cache, Microsoft.Extensions.Options.IOptions<GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions!>! options) -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.RemoveAsync(string! key) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.RenewAsync(string! key, Microsoft.AspNetCore.Authentication.AuthenticationTicket! ticket) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.RetrieveAsync(string! key) -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Authentication.AuthenticationTicket?>!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStore.StoreAsync(Microsoft.AspNetCore.Authentication.AuthenticationTicket! ticket) -> System.Threading.Tasks.Task<string!>!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.CacheEntryOptions.get -> Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.CacheEntryOptions.set -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.CacheKeyFactory.get -> System.Func<string!, string!>!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.CacheKeyFactory.set -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.DistributedCacheTicketStoreOptions() -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.SerializerOptions.get -> System.Text.Json.JsonSerializerOptions?
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.SerializerOptions.set -> void
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.TicketIdFactory.get -> System.Func<Microsoft.AspNetCore.Authentication.AuthenticationTicket!, string!>!
+GSS.Authentication.CAS.AspNetCore.DistributedCacheTicketStoreOptions.TicketIdFactory.set -> void
+GSS.Authentication.CAS.AspNetCore.ServiceTicketPropertiesExtensions
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.CreateEventsAsync() -> System.Threading.Tasks.Task<object!>!
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.HandleChallengeAsync(Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties) -> System.Threading.Tasks.Task!
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.HandleRemoteAuthenticateAsync() -> System.Threading.Tasks.Task<Microsoft.AspNetCore.Authentication.HandleRequestResult!>!
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationHandler.HandleRequestAsync() -> System.Threading.Tasks.Task<bool>!
+override GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions.Validate() -> void
+static GSS.Authentication.CAS.AspNetCore.CasExtensions.AddCAS(this Microsoft.AspNetCore.Authentication.AuthenticationBuilder! builder) -> Microsoft.AspNetCore.Authentication.AuthenticationBuilder!
+static GSS.Authentication.CAS.AspNetCore.CasExtensions.AddCAS(this Microsoft.AspNetCore.Authentication.AuthenticationBuilder! builder, string! authenticationScheme, string! displayName, System.Action<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>? configureOptions) -> Microsoft.AspNetCore.Authentication.AuthenticationBuilder!
+static GSS.Authentication.CAS.AspNetCore.CasExtensions.AddCAS(this Microsoft.AspNetCore.Authentication.AuthenticationBuilder! builder, string! authenticationScheme, System.Action<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>? configureOptions) -> Microsoft.AspNetCore.Authentication.AuthenticationBuilder!
+static GSS.Authentication.CAS.AspNetCore.CasExtensions.AddCAS(this Microsoft.AspNetCore.Authentication.AuthenticationBuilder! builder, System.Action<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>? configureOptions) -> Microsoft.AspNetCore.Authentication.AuthenticationBuilder!
+static GSS.Authentication.CAS.AspNetCore.CasSingleLogoutExtensions.UseCasSingleLogout(this Microsoft.AspNetCore.Builder.IApplicationBuilder! app, Microsoft.AspNetCore.Authentication.Cookies.ITicketStore? store = null, GSS.Authentication.CAS.AspNetCore.CasSingleLogoutOptions? options = null) -> Microsoft.AspNetCore.Builder.IApplicationBuilder!
+static GSS.Authentication.CAS.AspNetCore.ServiceTicketPropertiesExtensions.GetServiceTicket(this Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties) -> string?
+static GSS.Authentication.CAS.AspNetCore.ServiceTicketPropertiesExtensions.SetServiceTicket(this Microsoft.AspNetCore.Authentication.AuthenticationProperties! properties, string! ticket) -> void
+virtual GSS.Authentication.CAS.AspNetCore.CasEvents.CreatingTicket(GSS.Authentication.CAS.AspNetCore.CasCreatingTicketContext! context) -> System.Threading.Tasks.Task!
+virtual GSS.Authentication.CAS.AspNetCore.CasEvents.RedirectToAuthorizationEndpoint(Microsoft.AspNetCore.Authentication.RedirectContext<GSS.Authentication.CAS.AspNetCore.CasAuthenticationOptions!>! context) -> System.Threading.Tasks.Task!
+virtual GSS.Authentication.CAS.AspNetCore.CasEvents.RedirectToIdentityProviderForSignOut(GSS.Authentication.CAS.AspNetCore.CasRedirectContext! context) -> System.Threading.Tasks.Task!

--- a/src/GSS.Authentication.CAS.AspNetCore/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/GSS.Authentication.CAS.AspNetCore/PublicAPI/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/GSS.Authentication.CAS.Core/PublicAPI.Shipped.txt
+++ b/src/GSS.Authentication.CAS.Core/PublicAPI.Shipped.txt
@@ -1,0 +1,81 @@
+#nullable enable
+abstract GSS.Authentication.CAS.Validation.CasServiceTicketValidator.BuildPrincipal(string! responseBody, string? contentType) -> GSS.Authentication.CAS.Security.ICasPrincipal?
+const GSS.Authentication.CAS.CasDefaults.AuthenticationType = "CAS" -> string!
+const GSS.Authentication.CAS.Constants.Parameters.Gateway = "gateway" -> string!
+const GSS.Authentication.CAS.Constants.Parameters.Locale = "locale" -> string!
+const GSS.Authentication.CAS.Constants.Parameters.Method = "method" -> string!
+const GSS.Authentication.CAS.Constants.Parameters.ProxyGrantingTicketId = "pgtId" -> string!
+const GSS.Authentication.CAS.Constants.Parameters.ProxyGrantingTicketIou = "pgtIou" -> string!
+const GSS.Authentication.CAS.Constants.Parameters.Renew = "renew" -> string!
+const GSS.Authentication.CAS.Constants.Parameters.Service = "service" -> string!
+const GSS.Authentication.CAS.Constants.Parameters.Ticket = "ticket" -> string!
+const GSS.Authentication.CAS.Constants.Paths.Login = "/login" -> string!
+const GSS.Authentication.CAS.Constants.Paths.Logout = "/logout" -> string!
+GSS.Authentication.CAS.CasDefaults
+GSS.Authentication.CAS.CasOptions
+GSS.Authentication.CAS.CasOptions.AuthenticationType.get -> string!
+GSS.Authentication.CAS.CasOptions.AuthenticationType.set -> void
+GSS.Authentication.CAS.CasOptions.CasOptions() -> void
+GSS.Authentication.CAS.CasOptions.CasServerUrlBase.get -> string!
+GSS.Authentication.CAS.CasOptions.CasServerUrlBase.set -> void
+GSS.Authentication.CAS.Constants
+GSS.Authentication.CAS.Constants.Parameters
+GSS.Authentication.CAS.Constants.Paths
+GSS.Authentication.CAS.ICasOptions
+GSS.Authentication.CAS.ICasOptions.AuthenticationType.get -> string!
+GSS.Authentication.CAS.ICasOptions.CasServerUrlBase.get -> string!
+GSS.Authentication.CAS.PrincipalExtensions
+GSS.Authentication.CAS.Proxy.CasProxyTicketProvider
+GSS.Authentication.CAS.Proxy.CasProxyTicketProvider.CasProxyTicketProvider(GSS.Authentication.CAS.ICasOptions! options, System.Net.Http.HttpClient? httpClient = null) -> void
+GSS.Authentication.CAS.Proxy.CasProxyTicketProvider.GetProxyTicketAsync(string! proxyGrantingTicket, string! targetService, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+GSS.Authentication.CAS.Proxy.InMemoryProxyGrantingTicketStore
+GSS.Authentication.CAS.Proxy.InMemoryProxyGrantingTicketStore.GetAsync(string! proxyGrantingTicketIou, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
+GSS.Authentication.CAS.Proxy.InMemoryProxyGrantingTicketStore.InMemoryProxyGrantingTicketStore() -> void
+GSS.Authentication.CAS.Proxy.InMemoryProxyGrantingTicketStore.RemoveAsync(string! proxyGrantingTicketIou, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.Proxy.InMemoryProxyGrantingTicketStore.StoreAsync(string! proxyGrantingTicketIou, string! proxyGrantingTicket, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.Proxy.IProxyGrantingTicketStore
+GSS.Authentication.CAS.Proxy.IProxyGrantingTicketStore.GetAsync(string! proxyGrantingTicketIou, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string?>!
+GSS.Authentication.CAS.Proxy.IProxyGrantingTicketStore.RemoveAsync(string! proxyGrantingTicketIou, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.Proxy.IProxyGrantingTicketStore.StoreAsync(string! proxyGrantingTicketIou, string! proxyGrantingTicket, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.Proxy.IProxyTicketProvider
+GSS.Authentication.CAS.Proxy.IProxyTicketProvider.GetProxyTicketAsync(string! proxyGrantingTicket, string! targetService, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string!>!
+GSS.Authentication.CAS.Security.Assertion
+GSS.Authentication.CAS.Security.Assertion.Assertion(string! principalName, System.Collections.Generic.IDictionary<string!, Microsoft.Extensions.Primitives.StringValues>? attributes = null, string? proxyGrantingTicketIou = null, System.Collections.Generic.IReadOnlyList<string!>? proxies = null) -> void
+GSS.Authentication.CAS.Security.Assertion.Attributes.get -> System.Collections.Generic.IDictionary<string!, Microsoft.Extensions.Primitives.StringValues>!
+GSS.Authentication.CAS.Security.Assertion.PrincipalName.get -> string!
+GSS.Authentication.CAS.Security.Assertion.Proxies.get -> System.Collections.Generic.IReadOnlyList<string!>!
+GSS.Authentication.CAS.Security.Assertion.ProxyGrantingTicketIou.get -> string?
+GSS.Authentication.CAS.Security.CasIdentity
+GSS.Authentication.CAS.Security.CasIdentity.Assertion.get -> GSS.Authentication.CAS.Security.Assertion!
+GSS.Authentication.CAS.Security.CasIdentity.Assertion.set -> void
+GSS.Authentication.CAS.Security.CasIdentity.CasIdentity(GSS.Authentication.CAS.Security.Assertion! assertion, string! authenticationType) -> void
+GSS.Authentication.CAS.Security.CasPrincipal
+GSS.Authentication.CAS.Security.CasPrincipal.Assertion.get -> GSS.Authentication.CAS.Security.Assertion!
+GSS.Authentication.CAS.Security.CasPrincipal.Assertion.set -> void
+GSS.Authentication.CAS.Security.CasPrincipal.CasPrincipal(GSS.Authentication.CAS.Security.Assertion! assertion, string! authenticationType) -> void
+GSS.Authentication.CAS.Security.CasPrincipal.CasPrincipal(GSS.Authentication.CAS.Security.Assertion! assertion, string! authenticationType, System.Collections.Generic.IEnumerable<string!>? roles) -> void
+GSS.Authentication.CAS.Security.CasPrincipal.roles -> System.Collections.Generic.IEnumerable<string!>?
+GSS.Authentication.CAS.Security.ICasPrincipal
+GSS.Authentication.CAS.Security.ICasPrincipal.Assertion.get -> GSS.Authentication.CAS.Security.Assertion!
+GSS.Authentication.CAS.Validation.Cas10ServiceTicketValidator
+GSS.Authentication.CAS.Validation.Cas10ServiceTicketValidator.Cas10ServiceTicketValidator(GSS.Authentication.CAS.ICasOptions! options, System.Net.Http.HttpClient? httpClient = null) -> void
+GSS.Authentication.CAS.Validation.Cas20ProxyTicketValidator
+GSS.Authentication.CAS.Validation.Cas20ProxyTicketValidator.Cas20ProxyTicketValidator(GSS.Authentication.CAS.ICasOptions! options, System.Net.Http.HttpClient? httpClient = null) -> void
+GSS.Authentication.CAS.Validation.Cas20ServiceTicketValidator
+GSS.Authentication.CAS.Validation.Cas20ServiceTicketValidator.Cas20ServiceTicketValidator(GSS.Authentication.CAS.ICasOptions! options, System.Net.Http.HttpClient? httpClient = null) -> void
+GSS.Authentication.CAS.Validation.Cas20ServiceTicketValidator.Cas20ServiceTicketValidator(string! suffix, GSS.Authentication.CAS.ICasOptions! options, System.Net.Http.HttpClient? httpClient = null) -> void
+GSS.Authentication.CAS.Validation.Cas30ProxyTicketValidator
+GSS.Authentication.CAS.Validation.Cas30ProxyTicketValidator.Cas30ProxyTicketValidator(GSS.Authentication.CAS.ICasOptions! options, System.Net.Http.HttpClient? httpClient = null) -> void
+GSS.Authentication.CAS.Validation.Cas30ServiceTicketValidator
+GSS.Authentication.CAS.Validation.Cas30ServiceTicketValidator.Cas30ServiceTicketValidator(GSS.Authentication.CAS.ICasOptions! options, System.Net.Http.HttpClient? httpClient = null) -> void
+GSS.Authentication.CAS.Validation.CasServiceTicketValidator
+GSS.Authentication.CAS.Validation.CasServiceTicketValidator.CasServiceTicketValidator(string! suffix, GSS.Authentication.CAS.ICasOptions! options, System.Net.Http.HttpClient? httpClient = null) -> void
+GSS.Authentication.CAS.Validation.CasServiceTicketValidator.Options.get -> GSS.Authentication.CAS.ICasOptions!
+GSS.Authentication.CAS.Validation.IServiceTicketValidator
+GSS.Authentication.CAS.Validation.IServiceTicketValidator.ValidateAsync(string! ticket, string! service, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), string? proxyCallbackUrl = null) -> System.Threading.Tasks.Task<GSS.Authentication.CAS.Security.ICasPrincipal?>!
+override GSS.Authentication.CAS.Security.CasPrincipal.IsInRole(string! role) -> bool
+override GSS.Authentication.CAS.Validation.Cas10ServiceTicketValidator.BuildPrincipal(string! responseBody, string? contentType) -> GSS.Authentication.CAS.Security.ICasPrincipal?
+override GSS.Authentication.CAS.Validation.Cas20ServiceTicketValidator.BuildPrincipal(string! responseBody, string? contentType) -> GSS.Authentication.CAS.Security.ICasPrincipal?
+static GSS.Authentication.CAS.PrincipalExtensions.GetPrincipalName(this System.Security.Principal.IIdentity! identity) -> string!
+static GSS.Authentication.CAS.PrincipalExtensions.GetPrincipalName(this System.Security.Principal.IPrincipal! principal) -> string!
+virtual GSS.Authentication.CAS.Validation.CasServiceTicketValidator.ValidateAsync(string! ticket, string! service, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken), string? proxyCallbackUrl = null) -> System.Threading.Tasks.Task<GSS.Authentication.CAS.Security.ICasPrincipal?>!

--- a/src/GSS.Authentication.CAS.Core/PublicAPI.Unshipped.txt
+++ b/src/GSS.Authentication.CAS.Core/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/GSS.Authentication.CAS.Owin/PublicAPI.Shipped.txt
+++ b/src/GSS.Authentication.CAS.Owin/PublicAPI.Shipped.txt
@@ -1,0 +1,129 @@
+#nullable enable
+const GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Scheme = "CAS" -> string!
+GSS.Authentication.CAS.Owin.AuthenticationSessionStoreExtensions
+GSS.Authentication.CAS.Owin.CasAuthenticationExtensions
+GSS.Authentication.CAS.Owin.CasAuthenticationHandler
+GSS.Authentication.CAS.Owin.CasAuthenticationHandler.CasAuthenticationHandler(Microsoft.Owin.Logging.ILogger! logger) -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationMiddleware
+GSS.Authentication.CAS.Owin.CasAuthenticationMiddleware.CasAuthenticationMiddleware(Microsoft.Owin.OwinMiddleware! next, Owin.IAppBuilder! app, GSS.Authentication.CAS.Owin.CasAuthenticationOptions! options) -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.BackchannelFactory.get -> System.Func<GSS.Authentication.CAS.Owin.CasAuthenticationOptions!, System.Net.Http.HttpClient!>!
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.BackchannelFactory.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.BackchannelHttpHandler.get -> System.Net.Http.HttpMessageHandler?
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.BackchannelHttpHandler.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.BackchannelTimeout.get -> System.TimeSpan
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.BackchannelTimeout.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.CallbackPath.get -> Microsoft.Owin.PathString
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.CallbackPath.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Caption.get -> string!
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Caption.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.CasAuthenticationOptions() -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.CasServerUrlBase.get -> string!
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.CasServerUrlBase.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.CookieManager.get -> Microsoft.Owin.Infrastructure.ICookieManager!
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.CookieManager.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Gateway.get -> bool
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Gateway.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Locale.get -> string?
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Locale.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Method.get -> string?
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Method.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Provider.get -> GSS.Authentication.CAS.Owin.ICasAuthenticationProvider!
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Provider.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.ProxyCallbackPath.get -> Microsoft.Owin.PathString
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.ProxyCallbackPath.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.ProxyGrantingTicketStore.get -> GSS.Authentication.CAS.Proxy.IProxyGrantingTicketStore!
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.ProxyGrantingTicketStore.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Renew.get -> bool
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.Renew.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.SaveTokens.get -> bool
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.SaveTokens.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.ServiceTicketValidator.get -> GSS.Authentication.CAS.Validation.IServiceTicketValidator!
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.ServiceTicketValidator.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.ServiceUrlBase.get -> System.Uri?
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.ServiceUrlBase.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.SignedOutCallbackPath.get -> Microsoft.Owin.PathString
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.SignedOutCallbackPath.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.SignedOutRedirectUri.get -> string!
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.SignedOutRedirectUri.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.SignInAsAuthenticationType.get -> string?
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.SignInAsAuthenticationType.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.StateDataFormat.get -> Microsoft.Owin.Security.ISecureDataFormat<Microsoft.Owin.Security.AuthenticationProperties!>!
+GSS.Authentication.CAS.Owin.CasAuthenticationOptions.StateDataFormat.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider.CasAuthenticationProvider() -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider.OnCreatingTicket.get -> System.Func<GSS.Authentication.CAS.Owin.CasCreatingTicketContext!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider.OnCreatingTicket.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider.OnRedirectToAuthorizationEndpoint.get -> System.Func<GSS.Authentication.CAS.Owin.CasRedirectToAuthorizationEndpointContext!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider.OnRedirectToAuthorizationEndpoint.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider.OnRedirectToIdentityProviderForSignIn.get -> System.Func<GSS.Authentication.CAS.Owin.CasRedirectContext!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider.OnRedirectToIdentityProviderForSignIn.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider.OnRedirectToIdentityProviderForSignOut.get -> System.Func<GSS.Authentication.CAS.Owin.CasRedirectContext!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider.OnRedirectToIdentityProviderForSignOut.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider.OnRemoteFailure.get -> System.Func<GSS.Authentication.CAS.Owin.CasRemoteFailureContext!, System.Threading.Tasks.Task!>!
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider.OnRemoteFailure.set -> void
+GSS.Authentication.CAS.Owin.CasAuthenticationProvider.RemoteFailure(GSS.Authentication.CAS.Owin.CasRemoteFailureContext! context) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.Owin.CasCreatingTicketContext
+GSS.Authentication.CAS.Owin.CasCreatingTicketContext.CasCreatingTicketContext(Microsoft.Owin.IOwinContext! context, System.Security.Claims.ClaimsIdentity! identity, Microsoft.Owin.Security.AuthenticationProperties! properties) -> void
+GSS.Authentication.CAS.Owin.CasCreatingTicketContext.Identity.get -> System.Security.Claims.ClaimsIdentity!
+GSS.Authentication.CAS.Owin.CasCreatingTicketContext.Identity.set -> void
+GSS.Authentication.CAS.Owin.CasCreatingTicketContext.Properties.get -> Microsoft.Owin.Security.AuthenticationProperties!
+GSS.Authentication.CAS.Owin.CasCreatingTicketContext.Properties.set -> void
+GSS.Authentication.CAS.Owin.CasRedirectContext
+GSS.Authentication.CAS.Owin.CasRedirectContext.CasRedirectContext(Microsoft.Owin.IOwinContext! context, Microsoft.Owin.Security.AuthenticationTicket? ticket) -> void
+GSS.Authentication.CAS.Owin.CasRedirectContext.Handled.get -> bool
+GSS.Authentication.CAS.Owin.CasRedirectContext.HandleResponse() -> void
+GSS.Authentication.CAS.Owin.CasRedirectToAuthorizationEndpointContext
+GSS.Authentication.CAS.Owin.CasRedirectToAuthorizationEndpointContext.CasRedirectToAuthorizationEndpointContext(Microsoft.Owin.IOwinContext! context, Microsoft.Owin.Security.AuthenticationTicket? ticket) -> void
+GSS.Authentication.CAS.Owin.CasRemoteFailureContext
+GSS.Authentication.CAS.Owin.CasRemoteFailureContext.CasRemoteFailureContext(Microsoft.Owin.IOwinContext! context, System.Exception! failure) -> void
+GSS.Authentication.CAS.Owin.CasRemoteFailureContext.Failure.get -> System.Exception!
+GSS.Authentication.CAS.Owin.CasRemoteFailureContext.Failure.set -> void
+GSS.Authentication.CAS.Owin.CasRemoteFailureContext.HandleResponse() -> void
+GSS.Authentication.CAS.Owin.CasRemoteFailureContext.Properties.get -> Microsoft.Owin.Security.AuthenticationProperties?
+GSS.Authentication.CAS.Owin.CasRemoteFailureContext.Properties.set -> void
+GSS.Authentication.CAS.Owin.CasRemoteFailureContext.SkipHandler() -> void
+GSS.Authentication.CAS.Owin.CasSingleLogoutExtensions
+GSS.Authentication.CAS.Owin.CasSingleLogoutMiddleware
+GSS.Authentication.CAS.Owin.CasSingleLogoutMiddleware.CasSingleLogoutMiddleware(Microsoft.Owin.OwinMiddleware! next, Owin.IAppBuilder! app, Microsoft.Owin.Security.Cookies.IAuthenticationSessionStore! store, GSS.Authentication.CAS.Owin.CasSingleLogoutOptions? options = null) -> void
+GSS.Authentication.CAS.Owin.CasSingleLogoutOptions
+GSS.Authentication.CAS.Owin.CasSingleLogoutOptions.CasSingleLogoutOptions() -> void
+GSS.Authentication.CAS.Owin.CasSingleLogoutOptions.IsTrustedRequest.get -> System.Func<Microsoft.Owin.IOwinContext!, bool>!
+GSS.Authentication.CAS.Owin.CasSingleLogoutOptions.IsTrustedRequest.set -> void
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStore
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStore.DistributedCacheIAuthenticationSessionStore(Microsoft.Extensions.Caching.Distributed.IDistributedCache! cache, Microsoft.Extensions.Options.IOptions<GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStoreOptions!>! options) -> void
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStore.RemoveAsync(string! key) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStore.RenewAsync(string! key, Microsoft.Owin.Security.AuthenticationTicket! ticket) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStore.RetrieveAsync(string! key) -> System.Threading.Tasks.Task<Microsoft.Owin.Security.AuthenticationTicket?>!
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStore.StoreAsync(Microsoft.Owin.Security.AuthenticationTicket! ticket) -> System.Threading.Tasks.Task<string!>!
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStoreOptions
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStoreOptions.CacheEntryOptions.get -> Microsoft.Extensions.Caching.Distributed.DistributedCacheEntryOptions!
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStoreOptions.CacheEntryOptions.set -> void
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStoreOptions.CacheKeyFactory.get -> System.Func<string!, string!>!
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStoreOptions.CacheKeyFactory.set -> void
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStoreOptions.DistributedCacheIAuthenticationSessionStoreOptions() -> void
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStoreOptions.SerializerOptions.get -> System.Text.Json.JsonSerializerOptions?
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStoreOptions.SerializerOptions.set -> void
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStoreOptions.TicketIdFactory.get -> System.Func<Microsoft.Owin.Security.AuthenticationTicket!, string!>!
+GSS.Authentication.CAS.Owin.DistributedCacheIAuthenticationSessionStoreOptions.TicketIdFactory.set -> void
+GSS.Authentication.CAS.Owin.ICasAuthenticationProvider
+GSS.Authentication.CAS.Owin.ICasAuthenticationProvider.CreatingTicket(GSS.Authentication.CAS.Owin.CasCreatingTicketContext! context) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.Owin.ICasAuthenticationProvider.RedirectToAuthorizationEndpoint(GSS.Authentication.CAS.Owin.CasRedirectToAuthorizationEndpointContext! context) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.Owin.ICasAuthenticationProvider.RedirectToIdentityProviderForSignIn(GSS.Authentication.CAS.Owin.CasRedirectContext! context) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.Owin.ICasAuthenticationProvider.RedirectToIdentityProviderForSignOut(GSS.Authentication.CAS.Owin.CasRedirectContext! context) -> System.Threading.Tasks.Task!
+GSS.Authentication.CAS.Owin.ICasAuthenticationProvider.RemoteFailure(GSS.Authentication.CAS.Owin.CasRemoteFailureContext! context) -> System.Threading.Tasks.Task!
+override GSS.Authentication.CAS.Owin.CasAuthenticationHandler.ApplyResponseChallengeAsync() -> System.Threading.Tasks.Task!
+override GSS.Authentication.CAS.Owin.CasAuthenticationHandler.ApplyResponseGrantAsync() -> System.Threading.Tasks.Task!
+override GSS.Authentication.CAS.Owin.CasAuthenticationHandler.AuthenticateCoreAsync() -> System.Threading.Tasks.Task<Microsoft.Owin.Security.AuthenticationTicket!>!
+override GSS.Authentication.CAS.Owin.CasAuthenticationHandler.InvokeAsync() -> System.Threading.Tasks.Task<bool>!
+override GSS.Authentication.CAS.Owin.CasAuthenticationMiddleware.CreateHandler() -> Microsoft.Owin.Security.Infrastructure.AuthenticationHandler<GSS.Authentication.CAS.Owin.CasAuthenticationOptions!>!
+override GSS.Authentication.CAS.Owin.CasSingleLogoutMiddleware.Invoke(Microsoft.Owin.IOwinContext! context) -> System.Threading.Tasks.Task!
+static GSS.Authentication.CAS.Owin.AuthenticationSessionStoreExtensions.GetServiceTicket(this Microsoft.Owin.Security.AuthenticationProperties! properties) -> string?
+static GSS.Authentication.CAS.Owin.AuthenticationSessionStoreExtensions.SetServiceTicket(this Microsoft.Owin.Security.AuthenticationProperties! properties, string! ticket) -> void
+static GSS.Authentication.CAS.Owin.CasAuthenticationExtensions.UseCasAuthentication(this Owin.IAppBuilder! app, GSS.Authentication.CAS.Owin.CasAuthenticationOptions! options) -> Owin.IAppBuilder!
+static GSS.Authentication.CAS.Owin.CasAuthenticationExtensions.UseCasAuthentication(this Owin.IAppBuilder! app, System.Action<GSS.Authentication.CAS.Owin.CasAuthenticationOptions!>? configureOptions = null) -> Owin.IAppBuilder!
+static GSS.Authentication.CAS.Owin.CasSingleLogoutExtensions.UseCasSingleLogout(this Owin.IAppBuilder! app, Microsoft.Owin.Security.Cookies.IAuthenticationSessionStore! store, GSS.Authentication.CAS.Owin.CasSingleLogoutOptions? options = null) -> Owin.IAppBuilder!
+virtual GSS.Authentication.CAS.Owin.CasAuthenticationProvider.CreatingTicket(GSS.Authentication.CAS.Owin.CasCreatingTicketContext! context) -> System.Threading.Tasks.Task!
+virtual GSS.Authentication.CAS.Owin.CasAuthenticationProvider.RedirectToAuthorizationEndpoint(GSS.Authentication.CAS.Owin.CasRedirectToAuthorizationEndpointContext! context) -> System.Threading.Tasks.Task!
+virtual GSS.Authentication.CAS.Owin.CasAuthenticationProvider.RedirectToIdentityProviderForSignIn(GSS.Authentication.CAS.Owin.CasRedirectContext! context) -> System.Threading.Tasks.Task!
+virtual GSS.Authentication.CAS.Owin.CasAuthenticationProvider.RedirectToIdentityProviderForSignOut(GSS.Authentication.CAS.Owin.CasRedirectContext! context) -> System.Threading.Tasks.Task!

--- a/src/GSS.Authentication.CAS.Owin/PublicAPI.Unshipped.txt
+++ b/src/GSS.Authentication.CAS.Owin/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+#nullable enable


### PR DESCRIPTION
## Summary

Add public API tracking and approval testing using `Microsoft.CodeAnalysis.PublicApiAnalyzers` to prevent unintended breaking changes across library packages.

- Add `Microsoft.CodeAnalysis.PublicApiAnalyzers` (5.6.0) to `Directory.Packages.props` and reference it centrally in `src/Directory.Build.props`.
- Configure `AdditionalFiles` in `src/Directory.Build.props` to support both single project-level API files and target-framework-specific files (`PublicAPI/$(TargetFramework)/`).
- Baseline current public API surfaces into `PublicAPI.Shipped.txt` files for:
  - `GSS.Authentication.CAS.Core` (`netstandard2.0`, `netcoreapp3.1`)
  - `GSS.Authentication.CAS.Owin` (`netstandard2.0`, `net462`)
  - `GSS.Authentication.CAS.AspNetCore` (per-framework for `netcoreapp3.1`, `net8.0`, and `net10.0` due to `ISystemClock` constructor differences)
- Include empty `PublicAPI.Unshipped.txt` files with `#nullable enable` across all libraries for future tracking.