### PR TITLE
Add agent-facing conventions and align the documented test commands

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,6 @@
 
 - [ ] I have applied an appropriate **PR label** (required for release notes)
 - [ ] `dotnet build -c Release` passes with no warnings
-- [ ] `dotnet test` passes
+- [ ] `dotnet test --ignore-exit-code 8` passes
 - [ ] Added or updated tests for behavior changes
 - [ ] Public API changes include XML documentation comments

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-# Pull Request
-
 ## Description
 
 <!-- What does this PR do? Link to related issue if applicable (e.g. Fixes #123) -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+<!-- markdownlint-disable MD041 -->
+<!-- No top-level heading: GitHub renders the PR title above this body, and an
+     agent filling the template in copies whatever heading it finds here. -->
+
 ## Description
 
 <!-- What does this PR do? Link to related issue if applicable (e.g. Fixes #123) -->

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,10 @@ jobs:
           dotnet build -c Release
       - name: Test
         run: |
-          dotnet test --coverage --coverage-output-format cobertura --ignore-exit-code 8
+          # --minimum-expected-tests is a solution-wide floor (exit 9) so a
+          # collapsed suite fails CI; --ignore-exit-code 8 does not mask it.
+          # Raise the floor when the suite grows well past it.
+          dotnet test --coverage --coverage-output-format cobertura --ignore-exit-code 8 --minimum-expected-tests 300
           dotnet tool restore
           dotnet tool run reportgenerator
           [[ -f "./coverage/Summary.txt" ]] && cat "./coverage/Summary.txt"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,18 +6,6 @@ CAS 1.0/2.0/3.0 authentication middleware for ASP.NET Core and OWIN/Katana. NuGe
 
 All repo-facing content — code comments, commit messages, PR/issue titles and bodies, docs — is written in English, regardless of the conversation language used to produce it.
 
-## Commands
-
-```shell
-dotnet test --ignore-exit-code 8
-dotnet test --coverage --coverage-output-format cobertura --ignore-exit-code 8
-dotnet tool restore && dotnet tool run reportgenerator
-dotnet test --filter "Cas20ServiceTicketValidationTests" --ignore-exit-code 8
-cd owin && msbuild -noLogo -verbosity:minimal -restore   # Windows + MSBuild only
-aube lint && aube build                                   # samples/AspNetCoreReactSample/ClientApp
-cd e2e && aube install && aube exec -- playwright test    # requires Keycloak + samples running, see .devcontainer/
-```
-
 ## Toolchain
 
 Pinned in `@mise.toml`:
@@ -36,6 +24,8 @@ Pinned in `@mise.toml`:
 - Conventions: Central Package Management (CPM) in `@Directory.Packages.props` (never `Version=` in `.csproj`).
 - User docs: `@docs/configuration.md`, `@docs/single-sign-out.md`, `@docs/proxy-tickets.md`
 - E2E tests (Playwright Test, Node/aube): `@e2e/playwright.config.ts` (one project per sample app), `@e2e/support/`
+- Verification: `@docs/agents/verification.md` — the gate command, what proves it ran, and what cannot be verified locally.
+- Pull requests: `@docs/agents/pull-request.md` — adds to `@.github/PULL_REQUEST_TEMPLATE.md`, which stays authoritative on structure.
 - Agent skills config: issues on GitHub (`@docs/agents/issue-tracker.md`), triage labels (`@docs/agents/triage-labels.md`), domain docs layout (`@docs/agents/domain.md`).
 - Gotchas: `@docs/agents/lessons-learned.md` (e.g. running OWIN tests locally via Mono).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,8 @@ dotnet tool restore && dotnet tool run reportgenerator
 # E2E tests (requires Keycloak — see .devcontainer/)
 cd e2e
 aube install
-aube exec -- playwright install --with-deps chromium
+# On Linux, add --with-deps to also install the system libraries Chromium needs.
+aube exec -- playwright install chromium
 aube exec -- playwright test
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,10 @@ dotnet build
 
 ```shell
 # Unit + integration tests (no external dependencies)
-dotnet test
+dotnet test --ignore-exit-code 8
 
 # With code coverage report
-dotnet test --coverage --coverage-output-format cobertura
+dotnet test --coverage --coverage-output-format cobertura --ignore-exit-code 8
 dotnet tool restore && dotnet tool run reportgenerator
 
 # E2E tests (requires Keycloak — see .devcontainer/)
@@ -41,6 +41,14 @@ aube install
 aube exec -- playwright install chromium
 aube exec -- playwright test
 ```
+
+> **Why `--ignore-exit-code 8`?** Microsoft.Testing.Platform returns exit code
+> 8 for `Zero tests ran`. The solution has two test projects, so any `--filter`
+> naming a class that lives in only one of them makes the other report zero
+> tests and fails the run. The flag keeps one command form working filtered or
+> not. It does not hide test failures, which are exit code 2. CI adds
+> `--minimum-expected-tests 300` on top, a solution-wide floor that catches a
+> suite that collapsed to nothing; raise it when the suite grows well past it.
 
 ### Dev Container (recommended)
 
@@ -60,7 +68,7 @@ Open in VS Code with the [Dev Containers](https://marketplace.visualstudio.com/i
 
    ```shell
    dotnet build -c Release
-   dotnet test
+   dotnet test --ignore-exit-code 8
    ```
 
 4. **Apply one primary label** to your PR (required; release-drafter puts each PR in the first matching group):

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,6 +1,11 @@
 # Issue tracker: GitHub
 
+**This file is English throughout**, sample blocks included, so it reads
+one way to every model, whatever language the repo chose for its issues.
+
 Issues and specs for this repo (`akunzai/GSS.Authentication.CAS`) live as GitHub issues. Use the `gh` CLI for all operations.
+
+Write issue titles and descriptions in **English**, matching the Language rule in `AGENTS.md`.
 
 ## Conventions
 
@@ -12,6 +17,68 @@ Issues and specs for this repo (`akunzai/GSS.Authentication.CAS`) live as GitHub
 - **Close**: `gh issue close <number> --comment "..."`
 
 Infer the repo from `git remote -v`; `gh` does this automatically when run inside a clone.
+
+## Description shape
+
+1. Open with what a new engineer or a library consumer would observe: the symptom or the request, in plain language. Skip file paths and function names unless the reader cannot otherwise locate the issue.
+2. Add a visual GitHub renders inline — a Mermaid `sequenceDiagram` for a ticket-validation or single-sign-out flow, a screenshot for a sample-app bug. Skip formats the description editor cannot render, such as a link to an external artifact or a raw HTML or SVG file. Upload it with the repeatable `--attach` flag (`gh issue create --attach './bug.png#The error state'`); alt text follows the path after `#`. Only when capture is genuinely impossible, leave `<!-- screenshot pending: <what it should show> -->` rather than omitting it silently.
+3. Close with a collapsed technical section, so it does not push the human summary below the fold:
+
+```markdown
+<details>
+<summary>Technical details</summary>
+
+suspected cause, related code paths, repro commands, log excerpts
+
+</details>
+```
+
+**No personally identifiable information in any attachment**; use test data, masking, or cropping. CAS tickets, service URLs, and Keycloak accounts count as that data — `docs/agents/verification.md` holds the capture rules.
+
+## Spec issues
+
+An issue an agent will implement from carries a different shape, because its reader is building rather than triaging. Acceptance criteria stay above the fold; only background goes into `<details>`.
+
+```markdown
+<one paragraph: the observable outcome>
+
+## Acceptance criteria
+
+- [ ] <checkable statement about observable behaviour>
+- [ ] <one per criterion; a reviewer can tick these without reading code>
+
+## Scope
+
+- In: <paths or areas>
+- Out: <what this issue deliberately does not change>
+
+## Verification
+
+<how to prove it works, per docs/agents/verification.md; say here when this
+needs the Keycloak dev container or a Windows machine rather than the
+default `dotnet test` gate>
+
+<details>
+<summary>Technical details</summary>
+
+related code paths, prior art, log excerpts, open questions
+
+</details>
+```
+
+Use the vocabulary the project already defines for its domain, so the issue, the tests, and the code name the same things — CAS terms such as service ticket, proxy-granting ticket, and single sign-out keep their protocol meaning.
+
+An issue with unanswered open questions is not ready to implement. Say so in the issue rather than letting an agent guess.
+
+## Labels
+
+Read this repo's own labels with `gh label list --limit 100`; the CLI defaults to 30 and reports that page as the whole set, so a label past the first page reads as absent. Nothing here invents a vocabulary; when a label really is missing, that is a conversation with the maintainer, not a label to create.
+
+- **Triage roles** — `needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix` — are owned by `docs/agents/triage-labels.md`. Read that file, not this list.
+- **Applied when it applies**: `bug`, `enhancement`, `documentation`, `security`, `samples`, `dependencies`. One kind label per issue.
+- **Required on every issue**: none.
+
+Pull request labels are a separate vocabulary, driven by release notes. `CONTRIBUTING.md` owns that table.
 
 ## Pull requests as a triage surface
 

--- a/docs/agents/pull-request.md
+++ b/docs/agents/pull-request.md
@@ -1,0 +1,87 @@
+# Pull requests
+
+**This file is English throughout**, sample blocks included, whatever
+language the repo chose for its requests.
+
+Write PR titles, descriptions, and comments in **English**, matching the
+Language rule in `AGENTS.md`. **Git commit messages are English**,
+imperative, subject under 72 characters — they live in history and get
+searched by tooling.
+
+This repo's `.github/PULL_REQUEST_TEMPLATE.md` is authoritative on
+structure: Description, Type of Change, Checklist. What follows only adds
+what it does not say.
+
+## Preparing
+
+- Work on a feature branch. Never prepare a request from `main`.
+- Use a concise descriptive title with no Conventional Commit prefix,
+  because one request may carry more than one kind of change. Release
+  notes are grouped by label, not by title.
+- Apply exactly one primary label. `.github/release-drafter.yml` puts each
+  PR in the first matching group, and `label-check.yml` fails the request
+  without one. The table in `CONTRIBUTING.md` says which label to pick.
+- Link the issue in the Description with a closing keyword (`Fixes #123`).
+- **Do not open a request, draft included, without the developer asking.**
+
+## Description shape
+
+1. A plain-language opening: what changed and why, as a reviewer who did
+   not write it would need it.
+2. A visual GitHub renders inline, chosen by what changed:
+
+   | Change | Visual |
+   | --- | --- |
+   | CAS ticket flow, redirect, or single sign-out sequence | Mermaid `sequenceDiagram` |
+   | Handler or middleware state transition | Mermaid `flowchart` / `stateDiagram` |
+   | Sample app appearance | Before/after screenshots |
+   | Library-only change | None; test output instead |
+
+   Most changes here are library-only and need no diagram. Pair before and
+   after. At most one diagram unless it is such a pair.
+
+   Upload the file with the repeatable `--attach` flag —
+   `gh pr create --attach './after.png#After'`. Alt text follows the path
+   after `#`, and a path the body already references as
+   `![alt](./after.png)` is rewritten to point at the uploaded asset. Only
+   when capture is genuinely impossible, leave a named placeholder comment.
+3. A collapsed technical trailer holding affected paths, implementation
+   notes, verification commands, and log excerpts.
+
+**No personally identifiable information in any attachment**, whatever
+you end up attaching. `verification.md`'s capture rules say what that
+means here.
+
+## Tests land with the behaviour
+
+- **Product logic**: `src/GSS.Authentication.CAS.Core/`,
+  `src/GSS.Authentication.CAS.AspNetCore/`,
+  `src/GSS.Authentication.CAS.Owin/`. A change here lands with its tests in
+  the same request.
+- **Public API surface**: a change to a public type or member also updates
+  the matching `PublicAPI.Unshipped.txt`, per target framework for
+  `AspNetCore`. The approval test fails otherwise, and the diff is what a
+  reviewer reads to judge whether the change is breaking.
+- **Exempt**: `docs/`, `.github/`, `*.md`, `mise.toml`, and dependency
+  bumps with no behaviour change. `samples/` and `e2e/` are exempt from
+  unit tests; a behaviour change reaching a sample is covered by the
+  Playwright suite instead.
+- **Structurally untestable** code — options classes, DI extension methods,
+  all-static factories — is declared in the description, naming what covers
+  it instead.
+
+No coverage threshold. The reviewer judges whether the new behaviour is
+actually exercised.
+
+## Review readiness
+
+Nothing unverified enters review. Verify locally per `verification.md`,
+then open the request with the evidence. This repo publishes NuGet
+packages and has no deployed environment to verify against, so there is no
+draft-then-deploy path.
+
+State in the description which paths were verified and which were not,
+with the reason. A change touching `samples/` or `e2e/` names which
+Playwright projects were run. The OWIN `net48` tests are the one gate that
+commonly cannot run on a given machine; `verification.md` says what to
+write when they did not.

--- a/docs/agents/verification.md
+++ b/docs/agents/verification.md
@@ -1,0 +1,158 @@
+# Verification
+
+How an agent exercises a change in this repo before it reaches review.
+Human setup narrative lives in `CONTRIBUTING.md`; this file holds only
+what an agent needs.
+
+## Starting the environment
+
+```sh
+dotnet test --ignore-exit-code 8
+```
+
+There is no stack to start. This is a library, so the gate command is the
+verification.
+
+`--ignore-exit-code 8` covers a partial run. Microsoft.Testing.Platform
+reports exit code 8 for `Zero tests ran` under its strict zero-tests
+policy, so any `--filter` naming a class that lives in one test project
+only makes the other projects exit 8 and fails the whole run. The
+unfiltered gate reaches every project and exits 0 with or without the
+flag; it is carried on every command so one form works in both cases.
+Exit code 8 never means a test failed — that is exit code 2.
+
+The cost of that flag is that a suite which collapsed to nothing would
+also pass, so `.github/workflows/build.yml` adds
+`--minimum-expected-tests 300`, a solution-wide floor that fails with exit
+code 9. `--ignore-exit-code 8` does not mask exit code 9. Local runs skip
+the floor; the summary line is right there to read.
+
+<!-- drift:forge github -->
+<!-- drift:entrypoint-cmd dotnet test --ignore-exit-code 8 -->
+
+It never prompts. A step needing a human aborts non-zero naming the
+prerequisite — see Human prerequisites below.
+
+**Proof it ran**: the summary line reports `failed: 0` and a non-zero
+`total`. A run that reports `total: 0` proves nothing; the filter or the
+build is wrong.
+
+## Checks
+
+| What | Command |
+| --- | --- |
+| The gate | `dotnet test --ignore-exit-code 8` |
+| One test class while iterating | `dotnet test --filter "Cas20ServiceTicketValidationTests" --ignore-exit-code 8` |
+| Release build, zero warnings (`TreatWarningsAsErrors`) | `dotnet build -c Release` |
+| Coverage report | `dotnet test --coverage --coverage-output-format cobertura --ignore-exit-code 8` then `dotnet tool restore && dotnet tool run reportgenerator` |
+| React sample client | `aube lint && aube build` in `samples/AspNetCoreReactSample/ClientApp` |
+| OWIN targets (`net462`/`net48`) | `cd owin && msbuild -noLogo -verbosity:minimal -restore` — Windows + MSBuild only |
+| Browser E2E | See Browser E2E below; the suite needs Keycloak and a sample app already listening |
+
+A public API change also needs `PublicAPI.Unshipped.txt` updated, per
+target framework for `AspNetCore`; the approval test in the gate fails
+until it is.
+
+## Browser E2E
+
+Playwright has no `webServer` block, so nothing starts the stack for you.
+One Playwright project per sample, each expecting its own port. Run one
+project at a time, in this order.
+
+```sh
+# once per machine, and after a Keycloak image rebuild
+cd .devcontainer && docker compose up -d keycloak redis
+curl -sk -o /dev/null -w '%{http_code}\n' https://auth.dev.local:8443/realms/demo   # want 200
+
+# once per clone
+cd e2e && aube ci && aube exec -- playwright install chromium
+cd samples/AspNetCoreReactSample/ClientApp && aube ci   # the react project only
+
+# per project: start the sample, wait for it, then run that project alone
+dotnet run --project samples/AspNetCoreSample --urls https://localhost:5001 &
+cd e2e && aube exec -- playwright test --project=basic
+```
+
+`--with-deps` on `playwright install` is Linux-only; drop it elsewhere.
+
+| Playwright project | Sample | URL |
+| --- | --- | --- |
+| `basic` | `samples/AspNetCoreSample` | `https://localhost:5001` |
+| `mvc` | `samples/AspNetCoreMvcSample` | `https://localhost:5002` |
+| `blazor` | `samples/BlazorSample` | `https://localhost:5003` |
+| `identity` | `samples/AspNetCoreIdentitySample` | `https://localhost:5004` |
+| `react` | `samples/AspNetCoreReactSample` | `https://localhost:5005` |
+
+`.github/workflows/e2e-tests.yml` runs one matrix job per row and is the
+reference when this drifts.
+
+All five projects pass on macOS arm64 with Docker 29.4.0, so a failure
+here is a signal, not an environment quirk. Where a machine lacks Docker,
+mkcert, or the hosts entry, say the suite did not run rather than claiming
+a pass.
+
+Test credentials come from `.devcontainer/README.md`, and they are fixture
+accounts in a throwaway realm. Real credentials never enter this suite.
+
+## Human prerequisites
+
+Run once, by a person. The commands above fail until they are done.
+
+- [ ] Install the toolchain: `mise install` (.NET 10 SDK, the net8.0
+      ASP.NET Core runtime, Node, aube).
+- [ ] Install Docker and mkcert, for the Keycloak-backed E2E suite.
+- [ ] Issue the TLS certificate Keycloak mounts:
+      `cd .devcontainer && mkdir -p .secrets && mkcert -cert-file .secrets/cert.pem -key-file .secrets/key.pem auth.dev.local`.
+- [ ] Map the Keycloak hostname:
+      `echo "127.0.0.1 auth.dev.local" | sudo tee -a /etc/hosts`.
+- [ ] Trust the ASP.NET Core dev certificate: `dotnet dev-certs https --trust`.
+- [ ] For the OWIN targets outside Windows, install Mono. See
+      `docs/agents/lessons-learned.md` first; `--filter` does not work
+      under it, and one test fails on Apple Silicon on unmodified `main`.
+
+The `wizard` skill can turn this list into an interactive script. Do not
+have an agent run that script.
+
+## Ports
+
+Not applicable to the gate. The library has no listening service, so
+several agents can run `dotnet test` in the same clone at once.
+
+The dev container's Keycloak and the sample apps do listen, and their
+ports are fixed. **Only one agent runs the E2E stack at a time.**
+
+## Capturing evidence
+
+- Test output: paste the summary block from the gate. It is the primary
+  evidence for a library change.
+- Recording: the `to-walkthrough-video` skill for a sample-app flow,
+  `tcut` for a terminal session. Where neither is available, describe the
+  steps and attach a screenshot.
+- Screenshots: Playwright's own capture from `e2e/`, or the OS screenshot
+  tool for a sample app.
+
+**This document is where the capture rules live**, and
+`docs/agents/pull-request.md` points here rather than restating them. A
+capture taken on the developer's own machine carries their account's data,
+username, and home paths as readily as a shared environment does. CAS
+tickets, service URLs, and Keycloak accounts appearing in a log or a frame
+count as that data. Assert on the frame, a marker, or fixture data, and
+crop or mask what the tool happened to be showing.
+
+For a change behind a mode switch or feature flag, confirm the far end
+received the call. A healthy container and a green build are not evidence
+that an integration is wired up.
+
+## Not verified
+
+Say in the request which of these did not run, and why.
+
+- `owin/GSS.Authentication.CAS.Owin.Tests` (`net48`): needs Windows with
+  MSBuild, or Mono elsewhere. On Apple Silicon under Mono,
+  `SingleSignOut_ShouldRedirectToCasServer` fails on unmodified `main` —
+  see `docs/agents/lessons-learned.md` before reading a failure as a
+  regression.
+
+<!-- drift:file .devcontainer/devcontainer.json -->
+<!-- drift:file .devcontainer/compose.yaml -->
+<!-- drift:file e2e/playwright.config.ts -->

--- a/docs/agents/verification.md
+++ b/docs/agents/verification.md
@@ -151,7 +151,12 @@ Say in the request which of these did not run, and why.
   MSBuild, or Mono elsewhere. On Apple Silicon under Mono,
   `SingleSignOut_ShouldRedirectToCasServer` fails on unmodified `main` —
   see `docs/agents/lessons-learned.md` before reading a failure as a
-  regression.
+  regression. Neither `mono` nor `msbuild` is on PATH here, so this is a
+  missing dependency rather than a check nobody tried.
+
+A gap you could have closed is not a gap. Run the check whose dependency
+you have already seen running, and report a check you skipped as untried,
+rather than recording it here as one this repo cannot run.
 
 <!-- drift:file .devcontainer/devcontainer.json -->
 <!-- drift:file .devcontainer/compose.yaml -->


### PR DESCRIPTION
## Description

This repo already had `docs/agents/issue-tracker.md`, but nothing recorded how a change gets verified or how a pull request should be shaped. Two new documents fill that in, and a third round of edits fixes the command drift they exposed.

`docs/agents/verification.md` becomes the single source for the build and test commands, so `AGENTS.md` drops its `## Commands` block and points at the document instead. It records the gate command, what proves a run actually happened, and the Browser E2E recipe, which was verified end to end rather than transcribed: all five Playwright projects pass locally against the dev container Keycloak. The OWIN `net48` gate is the one thing left that cannot run everywhere.

`docs/agents/pull-request.md` defers to `.github/PULL_REQUEST_TEMPLATE.md` on structure and adds only what that template does not say, notably which paths must land with their tests and the `PublicAPI.Unshipped.txt` requirement.

Writing those documents surfaced two real inconsistencies, fixed in their own commits. The documented Playwright install carried `--with-deps`, which is Linux-only and fails on macOS. And the documented `dotnet test` invocations disagreed on whether they carried `--ignore-exit-code 8`; they now all do, with the reason written down, and CI gains a floor so the flag cannot hide a suite that collapsed to nothing.

A later commit adds the rule the `setup-agent-ready-repo` template now pins: a gap you could have closed is not a gap. The one entry under Not verified was audited against it and survives, because neither `mono` nor `msbuild` is on PATH, and it now says it was probed rather than assumed.

No diagram: this is documentation and CI configuration, with no runtime behaviour to draw.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (requires major version bump)
- [ ] Refactoring / maintenance
- [x] Documentation update
- [ ] Dependency update
- [x] CI/CD change

## Checklist

- [x] I have applied an appropriate **PR label** (required for release notes)
- [x] `dotnet build -c Release` passes with no warnings
- [x] `dotnet test --ignore-exit-code 8` passes
- [ ] Added or updated tests for behavior changes
- [ ] Public API changes include XML documentation comments

No product code changed, so no tests were added and no public API moved.

<details>
<summary>Technical details</summary>

**Why `--minimum-expected-tests` does not simply replace `--ignore-exit-code 8`**

The platform documentation says an explicit minimum supersedes the zero-tests policy. That holds inside a single test app. `dotnet test` here builds four test apps, two projects times two target frameworks, and the apps that ran zero tests still surface exit 8 through the solution-level run. Measured on this branch:

| Command | Exit |
| --- | --- |
| `dotnet test --filter "Cas20ServiceTicketValidationTests" --minimum-expected-tests 1` | 8 |
| `dotnet test --filter "Cas20ServiceTicketValidationTests" --ignore-exit-code 8 --minimum-expected-tests 1` | 0 |
| `dotnet test --ignore-exit-code 8 --minimum-expected-tests 1000` | 9 |
| `dotnet test --ignore-exit-code 8 --minimum-expected-tests 300` | 0 |

The third row is the one that matters: `--ignore-exit-code 8` does not mask exit 9, so the floor stays enforced. The threshold is aggregated across the solution, not evaluated per app, which the failure message confirms with `tests ran 330, minimum expected 1000`.

`.github/workflows/build-owin.yml` is deliberately untouched. `owin/global.json` selects the VSTest runner, where exit code 8 has no meaning.

**Verification run**

```
dotnet test --ignore-exit-code 8 --minimum-expected-tests 300
  total: 330
  failed: 0
  succeeded: 330
```

Browser E2E, one Playwright project per sample against `.devcontainer` Keycloak: basic 7 passed, mvc 4 passed, blazor 8 passed, identity 5 passed, react 9 passed.

Not run: `owin/GSS.Authentication.CAS.Owin.Tests` (`net48`), which needs Windows with MSBuild or Mono. No file under `owin/` changed.

**Affected paths**

- `docs/agents/verification.md`, `docs/agents/pull-request.md` (new)
- `docs/agents/issue-tracker.md`, `AGENTS.md`, `CONTRIBUTING.md`
- `.github/PULL_REQUEST_TEMPLATE.md`, `.github/workflows/build.yml`

</details>

