### PR TITLE
Align AGENTS.md pointers and recurrence wording with agents-md standard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,38 +8,38 @@ All repo-facing content — code comments, commit messages, PR/issue titles and 
 
 ## Toolchain
 
-Pinned in `@mise.toml`:
-- **.NET**: `@global.json` SDK 10.x builds all TFMs; net8.0 is runtime-only for tests/samples.
+Pinned in `mise.toml`:
+- **.NET**: `global.json` SDK 10.x builds all TFMs; net8.0 is runtime-only for tests/samples.
 - **Node**: React sample and `e2e/` use [aube](https://aube.jdx.dev) (`aube ci` for frozen install).
 
 ## Pointers
 
 - Solutions: `CAS.slnx` (main), `owin/Owin.sln` (Windows-only)
-- Ticket validation: `@src/GSS.Authentication.CAS.Core/Validation/IServiceTicketValidator.cs`
-- Proxy tickets (PGT/PGTIOU, `/proxy`): `@src/GSS.Authentication.CAS.Core/Proxy/`
-- AspNetCore handler & SLO: `@src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs`, `DistributedCacheTicketStore.cs`, `CasSingleLogoutOptions.cs`
+- Ticket validation: `src/GSS.Authentication.CAS.Core/Validation/IServiceTicketValidator.cs`
+- Proxy tickets (PGT/PGTIOU, `/proxy`): `src/GSS.Authentication.CAS.Core/Proxy/`
+- AspNetCore handler & SLO: `src/GSS.Authentication.CAS.AspNetCore/CasAuthenticationHandler.cs`, `DistributedCacheTicketStore.cs`, `CasSingleLogoutOptions.cs`
 - Gold-standard tests:
-  - `@test/GSS.Authentication.CAS.Core.Tests/Cas20ServiceTicketValidationTests.cs`
-  - `@test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationMiddlewareTests.cs`
-- Conventions: Central Package Management (CPM) in `@Directory.Packages.props` (never `Version=` in `.csproj`).
-- User docs: `@docs/configuration.md`, `@docs/single-sign-out.md`, `@docs/proxy-tickets.md`
-- E2E tests (Playwright Test, Node/aube): `@e2e/playwright.config.ts` (one project per sample app), `@e2e/support/`
-- Verification: `@docs/agents/verification.md` — the gate command, what proves it ran, and what cannot be verified locally.
-- Pull requests: `@docs/agents/pull-request.md` — adds to `@.github/PULL_REQUEST_TEMPLATE.md`, which stays authoritative on structure.
-- Agent skills config: issues on GitHub (`@docs/agents/issue-tracker.md`), triage labels (`@docs/agents/triage-labels.md`), domain docs layout (`@docs/agents/domain.md`).
-- Gotchas: `@docs/agents/lessons-learned.md` (e.g. running OWIN tests locally via Mono).
+  - `test/GSS.Authentication.CAS.Core.Tests/Cas20ServiceTicketValidationTests.cs`
+  - `test/GSS.Authentication.CAS.AspNetCore.Tests/CasAuthenticationMiddlewareTests.cs`
+- Conventions: Central Package Management (CPM) in `Directory.Packages.props` (never `Version=` in `.csproj`).
+- User docs: `docs/configuration.md`, `docs/single-sign-out.md`, `docs/proxy-tickets.md`
+- E2E tests (Playwright Test, Node/aube): `e2e/playwright.config.ts` (one project per sample app), `e2e/support/`
+- Before running or reporting verification, read `docs/agents/verification.md` — the gate command, what proves it ran, and what cannot be verified locally.
+- When opening a pull request, read `docs/agents/pull-request.md` — adds to `.github/PULL_REQUEST_TEMPLATE.md`, which stays authoritative on structure.
+- When filing or triaging an issue, read `docs/agents/issue-tracker.md` (triage labels: `docs/agents/triage-labels.md`, domain docs layout: `docs/agents/domain.md`).
+- Gotchas: `docs/agents/lessons-learned.md` (e.g. running OWIN tests locally via Mono).
 
 ## Constraints
 
 > [!WARNING]
 > **OWIN ecosystem is frozen** — `Microsoft.Owin.*` 4.2.3, `Sustainsys.Saml2.AspNetCore2` 2.11.0 final.
 
-- E2E tests require Keycloak + CAS protocol extension (`@.devcontainer/`).
+- E2E tests require Keycloak + CAS protocol extension (`.devcontainer/`).
 
 ## Prevent Recurrence
 
 - **Candidate**: Name who hits this again, in which file, on what change. No such scenario, nothing to propose.
-- **Promote**: Offer the first tier that reaches them and only that one, pending confirmation — enforce it (assert/type/test) with its size quoted, else a comment at that site, else an agent-facing doc (`docs/agents/<topic>.md`, else `docs/agents/lessons-learned.md`) with one `@path` line under Pointers and one sentence on why the tiers above cannot hold it.
+- **Promote**: Offer the first tier that reaches them and only that one, pending confirmation — enforce it (assert/type/test) with its size quoted, else a comment at that site, else an agent-facing doc (`docs/agents/<topic>.md`, else `docs/agents/lessons-learned.md`) with one backtick-path line under Pointers and one sentence on why the tiers above cannot hold it.
 - **Prune**: When adding to a file, audit the rest of it in the same pass. Drop entries once stale (obsolete version, now enforced, duplicated, or a transcript) — not by a fixed count.
 
 ## Claude Code Compatibility


### PR DESCRIPTION
## Description

Convert `@path` file references in `AGENTS.md` to standard backtick paths, and update agent document pointers to use occasion-based read triggers (`When filing or triaging...`, `When opening a pull request...`, `Before running or reporting verification...`).

In tools like Copilot CLI and Claude Code, `@path` triggers eager full-file expansion on every turn, unnecessarily bloating prompt context. Standardizing to backtick paths avoids eager expansion while keeping clean references.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change (requires major version bump)
- [ ] Refactoring / maintenance
- [x] Documentation update
- [ ] Dependency update
- [ ] CI/CD change

## Checklist

- [x] I have applied an appropriate **PR label** (required for release notes)
- [x] `dotnet build -c Release` passes with no warnings
- [x] `dotnet test --ignore-exit-code 8` passes
- [ ] Added or updated tests for behavior changes
- [ ] Public API changes include XML documentation comments

<details>
<summary>Technical details</summary>

### Verification
- `dotnet build -c Release`: Passed with 0 warnings and 0 errors.
- `dotnet test --ignore-exit-code 8`: Passed with 330 tests succeeded, 0 failed.
- `check-drift.sh`: Passed (forge github, entrypoint dotnet test, required files present).
- `install-templates.sh --check`: Passed with all guarantees met and no `@path` file references.

OWIN Windows-only tests (`net48` / `net462`) were not run locally as verification took place in a macOS arm64 environment.

</details>